### PR TITLE
wl SA 0ML9C3ZGB0LH2ZWF add triage tests

### DIFF
--- a/tests/test_triage_audit.py
+++ b/tests/test_triage_audit.py
@@ -1,0 +1,117 @@
+import json
+import os
+import glob
+import datetime as dt
+import subprocess
+
+from ampa.scheduler import (
+    Scheduler,
+    CommandSpec,
+    SchedulerConfig,
+    SchedulerStore,
+)
+import ampa.daemon as daemon
+
+
+class DummyStore(SchedulerStore):
+    def __init__(self) -> None:
+        # in-memory store
+        self.path = ":memory:"
+        self.data = {"commands": {}, "state": {}, "last_global_start_ts": None}
+
+    def save(self) -> None:
+        return None
+
+
+def make_scheduler(run_shell_callable, tmp_path):
+    store = DummyStore()
+    config = SchedulerConfig(
+        poll_interval_seconds=1,
+        global_min_interval_seconds=1,
+        priority_weight=0.1,
+        store_path=str(tmp_path / "store.json"),
+        llm_healthcheck_url="http://localhost/health",
+        max_run_history=5,
+    )
+    sched = Scheduler(
+        store, config, run_shell=run_shell_callable, command_cwd=str(tmp_path)
+    )
+    return sched
+
+
+def test_triage_audit_runs_and_cleans_temp(tmp_path, monkeypatch):
+    """Verify triage-audit flow executes audit command and removes temp comment file."""
+    calls = []
+    work_id = "TEST-WID-123"
+
+    # dummy send_webhook so scheduler doesn't try real network
+    monkeypatch.setattr(daemon, "send_webhook", lambda *a, **k: None)
+
+    def fake_run_shell(cmd, **kwargs):
+        calls.append(cmd)
+        # wl in-progress
+        if cmd.strip() == "wl in-progress --json":
+            out = json.dumps(
+                {
+                    "workItems": [
+                        {
+                            "id": work_id,
+                            "title": "Test item",
+                            "updated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+                        }
+                    ]
+                }
+            )
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout=out, stderr=""
+            )
+        # wl comment list <work>
+        if cmd.strip().startswith(f"wl comment list {work_id}"):
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout=json.dumps({"comments": []}), stderr=""
+            )
+        # opencode audit
+        if cmd.strip().startswith(f'opencode run "/audit {work_id}"'):
+            # return some stdout that includes a Summary: section
+            out = "Summary:\nThis is a short summary line.\n\nDetails:\nMore info"
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout=out, stderr=""
+            )
+        # wl comment add
+        if cmd.strip().startswith(f"wl comment add {work_id}"):
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout=json.dumps({"success": True}), stderr=""
+            )
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    sched = make_scheduler(fake_run_shell, tmp_path)
+
+    spec = CommandSpec(
+        command_id="wl-triage-audit",
+        command="true",
+        requires_llm=False,
+        frequency_minutes=1,
+        priority=0,
+        metadata={"truncate_chars": 65536, "audit_cooldown_hours": 0},
+        command_type="triage-audit",
+    )
+    sched.store.add_command(spec)
+
+    # ensure no pre-existing temp files for this work id
+    pre = glob.glob(f"/tmp/wl-audit-comment-{work_id}-*.md")
+    assert not pre
+
+    # set a fake webhook so summary extraction path runs (send_webhook is a noop)
+    monkeypatch.setenv("AMPA_DISCORD_WEBHOOK", "http://example.invalid/webhook")
+
+    # run the command (this will invoke our fake_run_shell)
+    sched.start_command(spec)
+
+    # ensure audit command was called
+    assert any(f"/audit {work_id}" in c for c in calls)
+    # ensure a wl comment add was attempted
+    assert any(c.startswith(f"wl comment add {work_id}") for c in calls)
+
+    # ensure temp files for this work id were removed
+    post = glob.glob(f"/tmp/wl-audit-comment-{work_id}-*.md")
+    assert not post


### PR DESCRIPTION
- **SA-0ML7OB15A0HU5NKZ: Add Dockerfile, requirements, Makefile and container README**
- **SA-0ML7OB15A0HU5NKZ: Move containerization assets into APMA/ directory**
- **SA-0ML7OB15A0HU5NKZ: Remove root-level containerization files (moved into APMA/)**
- **SA-0ML7OB15A0HU5NKZ: Makefile: auto-create XDG_RUNTIME_DIR helper; README: recommend make**
- **update opencode and add Qwen3-Coder-Next model**
- **APMA/Makefile: use podman --isolation chroot to avoid sd-bus permission errors in rootless builds**
- **APMA/Makefile: fix shell conditionals (avoid multi-line if blocks)**
- **APMA/Makefile: simplify one-line recipes to avoid /bin/sh parsing issues**
- **APMA/Dockerfile: avoid useradd during build; chown to UID 1000 and run as UID to support rootless builders**
- **CI: add GitHub Action to build APMA image and smoke-run for PR validation**
- **docs: add container run instructions and recommend Makefile usage**
- **docs: add quick-test and daemon run instructions for AMPA**
- **docs: remove quick-test; add .env injection example for container runs**
- **config: add comprehensive APMA .env (tracked) and allow ampa/.env in .gitignore**
- **revert: stop tracking ampa/.env and restore .gitignore**
- **chore: consolidate APMA -> ampa (standardize lowercase); move container files**
- **chore: add lower-case ampa container files (consolidation)**
- **ampa/Dockerfile: run package module (python -m ampa.daemon) instead of missing script**
- **Makefile: include local .env automatically when present for run target**
- **pkg: add ampa.__init__ to make the package importable in container**
- **Makefile: force rebuild with --no-cache to include recent source changes**
- **chore: fix CI paths to use lowercase ampa directory**
- **feat(make): add stop target and port-in-use check for run**
- **fix(make): robust port check and stop implementation for podman/docker**
- **chore: add helper script to run ampa container reliably**
- **chore(make): delegate run logic to scripts/run.sh to avoid quoting pitfalls**
- **SA-0ML8P67EQ1W1ZG9F: prevent baked-in .env from overriding webhook**
- **avoid using @ opencode in wl items as when pushed to github they trigger a notification for a person using that name for many years**
- **SA-0ML7Q2XI11OO3S5I: add scheduler daemon and CLI-first docs**
- **SA-0ML8W3DLN19NCQVX: send webhook payloads as plain text**
- **SA-0ML95LRFD08CS2CZ: run scheduler commands from start cwd**
- **SA-0ML95PIMU121DSNQ: remove APMA container workflow**
- **Add scheduler store example and ignore runtime store**
- **Stop tracking runtime scheduler store (ignored)**
- **SA-0ML96LPVC19CD40C: add wl-triage-audit command and triage flow**
- **SA-0ML7OB0U70BVLHF7: Add dead_letter() fallback for final-failure handling**
- **SA-0ML96LPVC19CD40C: Triage audit flow tweaks (temp-file cleanup, dead-letter helper added)**
- **SA-0ML9C3ZGB0LH2ZWF: Add unit test for triage-audit flow (temp-file cleanup + summary extraction)**
