### PR TITLE
docs: clarify daemon scheduler flags and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ A lightweight collection of workflow guides, command patterns, and skill templat
 2. Pick a folder to work in (e.g., `skill/` or `agent/`).
 3. Follow the appropriate guide (see files inside each folder) to implement, test, and package your work.
 
+Daemon / scheduler note
+
+- Some packages in this repository provide a long-running "daemon" that can
+  either perform a one-off action or run a scheduler loop. By default those
+  daemons often send a single heartbeat and exit; to run the scheduler loop
+  you must explicitly enable it (for example: use `--start-scheduler` or set
+  an environment flag like `AMPA_RUN_SCHEDULER=1`). Check the package README
+  (for example `ampa/README.md`) for the exact flag and environment variables.
+
 ## Contributing
 - Open an issue describing the change you'd like to make.
 - Follow the relevant guide under `command/` for design and review steps.

--- a/ampa/README.md
+++ b/ampa/README.md
@@ -52,11 +52,32 @@ Add the runtime dependencies and install them in your environment:
 
 Run as a daemon
 
-   # Run daemon in the foreground and start scheduler loop
-   AMPA_DISCORD_WEBHOOK="https://discord.com/api/webhooks/XXX" python -m ampa.daemon --start-scheduler
+The daemon defaults to sending a single heartbeat and exiting. To run the
+scheduler loop under the daemon runtime you must explicitly enable it either
+with the `--start-scheduler` flag or the `AMPA_RUN_SCHEDULER` environment
+variable.
 
-   # Alternatively, run a single heartbeat once
-   AMPA_DISCORD_WEBHOOK="https://discord.com/api/webhooks/XXX" python -m ampa.daemon --once
+Examples:
+
+  # Run daemon in the foreground and start the scheduler loop (recommended for testing)
+  AMPA_DISCORD_WEBHOOK="https://discord.com/api/webhooks/XXX" python -m ampa.daemon --start-scheduler
+
+  # Enable scheduler via environment variable instead of the CLI flag
+  AMPA_DISCORD_WEBHOOK="https://discord.com/api/webhooks/XXX" AMPA_RUN_SCHEDULER=1 python -m ampa.daemon
+
+  # Send a single heartbeat and exit
+  AMPA_DISCORD_WEBHOOK="https://discord.com/api/webhooks/XXX" python -m ampa.daemon --once
+
+Notes:
+
+- The scheduler uses the current working directory as the `command_cwd` for
+  commands it runs, so start the daemon from the directory you want commands
+  to execute in.
+- Ensure `AMPA_DISCORD_WEBHOOK` is set (or `ampa/.env` is present) before
+  starting the daemon; missing webhook will cause the daemon to exit.
+- Install runtime dependencies when running locally:
+
+  pip install -r ampa/requirements.txt
 
 Scheduler admin CLI
 


### PR DESCRIPTION
Explain that the daemon defaults to a single heartbeat and that the scheduler loop must be enabled with --start-scheduler or AMPA_RUN_SCHEDULER=1. Add examples and notes about command working directory, webhook config, and dependencies.\n\nFiles changed:\n- README.md\n- ampa/README.md\n