### PR TITLE
wl SA 0MLG0I5RA1U14U75 pre dispatch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,10 +89,10 @@ IMPORTANT: This project uses Worklog (wl) for ALL work-item tracking. Do NOT use
 
 - Use Worklog (wl), described below, for ALL task tracking, do NOT use markdown TODOs, task lists, or other tracking methods
 - _NEVER_ write directly to `.worklog/worklog-data.jsonl` unless you are given permission to do so by a Producer, and you have confirmed the correct format and structure of the data to be added. Use `wl` commands to interact with the worklog data. All manipulation of work items must be done through `wl` commands to ensure data integrity and consistency.
-- Whenever you are provided with, or discover, a new work item create it in wl immediately
-- Whenever you are provided with or discover important context (specifications, designs, user-stories) ensure the information is added to the description of the relevant work item(s) OR create a new work item if none exist
-- Whenever you create a planning document (PRD, spec, design doc) add references to the document in the description of any work item that is directly related to the document
 - A child work-item may be closed independently; however, a parent work-item can only be closed once all of its child work-items are closed, all blocking dependencies are resolved, and a Producer has reviewed and approved the work
+- Always ensure that work-items are kept up to date and accurately reflect the current state of the work. This includes updating descriptions, acceptance criteria, stages, and comments as needed throughout the lifecycle of the work.
+- Always ensure that any work-item created is associated with a clear goal and context, preferably in the form of a user story, along with measurable and testable acceptance criteria. If the requirements are not clear, seek clarification and update the work-item accordingly before proceeding with implementation.
+- When writing content for work-item descriptions, comments, or commit messages, do not escape special character EXCEPT backticks. Use markdown formatting as needed for clarity and readability, but do not add unnecessary escaping that could reduce readability or cause confusion.
 - Never commit changes without associating them with a work item
 - Never commit changes without ensuring all tests and quality checks pass
 - Always record the commit message and hash of any commits made in a comment on the relevant work item(s)

--- a/docs/delegation-control.md
+++ b/docs/delegation-control.md
@@ -1,0 +1,55 @@
+# Controlling AMPA Delegation
+
+This document explains how to prevent the Automated PM Agent (AMPA) from delegating a specific work item, and how AMPA reports that decision.
+
+When AMPA runs its delegation flow it considers candidates returned by `wl next` and acts only on items whose workflow *stage* is one of:
+
+- `idea`
+- `intake_complete`
+- `plan_complete`
+
+If you want to stop a particular work item from being delegated there are three supported, auditable approaches (ordered by recommended usage):
+
+1) Add a `do-not-delegate` tag (recommended)
+
+- Use: `wl tag add <WORK_ID> do-not-delegate`
+- AMPA checks candidates for the tag (case-insensitive) and will skip the item when present.
+- When a candidate is skipped for this reason AMPA logs an INFO line such as:
+
+  Delegation skipping candidate SA-12345 (Title): marked do-not-delegate
+
+- This is auditable: the tag remains on the work item and appears in `wl show` and WL history.
+
+2) Set an unsupported stage (quick manual stop)
+
+- Change the work item's `stage` to anything other than the actionable stages above (for example `backlog` or `closed`).
+- Examples:
+  - Interactive: `wl edit <WORK_ID>` and set `stage` to `backlog`.
+  - Non-interactive (if supported): `wl update <WORK_ID> --stage backlog`
+
+3) Set per-item metadata to block delegation
+
+- Add `do_not_delegate` (or `no_delegation`) to the work-item metadata and set it truthy (`true`, `1`, etc.).
+- Example payload: `{"do_not_delegate": true}` (how to supply depends on your WL client).
+
+How AMPA evaluates the signal
+
+- The scheduler uses the helper `_is_do_not_delegate(candidate)` which checks, in order:
+  1. `tags` (list or comma-separated string) for `do-not-delegate` or `do_not_delegate`.
+  2. `metadata` / `meta` dictionary for `do_not_delegate` or `no_delegation` truthy values.
+  3. explicit `do_not_delegate` boolean/string field on the candidate.
+- If the function returns `True` the candidate is skipped and AMPA continues to the next candidate.
+
+Logging & Discord
+
+- When a candidate is skipped due to the tag, AMPA logs at INFO level (see above). This keeps the decision visible but non-fatal in logs.
+- Unsupported stages are logged at ERROR and reported to Discord (AMPA will continue trying later candidates).
+- When AMPA dispatches a delegation it posts a follow-up delegation report to the configured Discord webhook summarizing the post-dispatch state.
+
+Recommended practice
+
+1. Prefer the `do-not-delegate` tag for explicit, auditable per-item control.
+2. Use stage changes for quick one-off stops when editing the item is acceptable.
+3. If you need stricter enforcement (e.g. notification when delegation is attempted), ask to enable automatic WL comments when AMPA skips a tagged item — this can be added.
+
+If you want me to: (a) add a WL comment whenever AMPA skips an item for `do-not-delegate`, or (b) create a runbook snippet with copy/paste commands for triage engineers, tell me which and I'll add it.

--- a/tests/test_delegation_dispatch.py
+++ b/tests/test_delegation_dispatch.py
@@ -1,0 +1,135 @@
+import json
+import subprocess
+import datetime as dt
+
+from ampa import scheduler
+from ampa.scheduler import CommandSpec, SchedulerConfig, SchedulerStore, Scheduler
+from ampa import webhook as webhook_module
+
+
+class DummyStore(SchedulerStore):
+    def __init__(self) -> None:
+        self.path = ":memory:"
+        self.data = {
+            "commands": {},
+            "state": {},
+            "last_global_start_ts": None,
+            "config": {},
+            "dispatches": [],
+        }
+
+    def save(self) -> None:
+        return None
+
+
+def make_scheduler(run_shell_callable, tmp_path):
+    store = DummyStore()
+    config = SchedulerConfig(
+        poll_interval_seconds=1,
+        global_min_interval_seconds=1,
+        priority_weight=0.1,
+        store_path=str(tmp_path / "store.json"),
+        llm_healthcheck_url="http://localhost/health",
+        max_run_history=5,
+    )
+    sched = Scheduler(
+        store, config, run_shell=run_shell_callable, command_cwd=str(tmp_path)
+    )
+    return sched
+
+
+def test_dispatch_logged_before_spawn(tmp_path, monkeypatch):
+    """Verify a dispatch record is persisted before opencode is spawned.
+
+    This test patches the store.append_dispatch to record that it ran and
+    ensures the opencode child process is invoked only after the dispatch
+    persistence has occurred. It also checks that a pre-dispatch webhook was
+    issued containing the dispatch id.
+    """
+    calls = []
+    state = {"append_called": False}
+    captured = {"calls": []}
+
+    # fake wl in_progress -> no in-progress items
+    # wl next -> return a candidate
+    def fake_run_shell(cmd, **kwargs):
+        calls.append(cmd)
+        s = cmd.strip()
+        if s == "wl in_progress --json":
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout=json.dumps({"workItems": []}), stderr=""
+            )
+        if s == "wl next --json":
+            payload = {
+                "workItem": {"id": "SA-TEST-123", "title": "Idea item", "stage": "idea"}
+            }
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout=json.dumps(payload), stderr=""
+            )
+        if s.startswith("opencode run"):
+            # opencode should only be called after append_dispatch
+            assert state["append_called"] is True, (
+                "opencode spawned before dispatch was recorded"
+            )
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="ok", stderr=""
+            )
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    sched = make_scheduler(fake_run_shell, tmp_path)
+
+    # patch append_dispatch to mark it called and return a stable id
+    def fake_append_dispatch(record, retain_last=100):
+        state["append_called"] = True
+        # mimic normal behaviour of assigning id and ts
+        record = dict(record)
+        record.setdefault("id", "DISPATCH-1")
+        record.setdefault("ts", dt.datetime.now(dt.timezone.utc).isoformat())
+        sched.store.data.setdefault("dispatches", []).append(record)
+        return record["id"]
+
+    monkeypatch.setattr(sched.store, "append_dispatch", fake_append_dispatch)
+
+    # capture webhook calls and assert message_type dispatch and payload contains id
+    def fake_send_webhook(url, payload, timeout=10, message_type="other"):
+        captured["calls"].append(
+            {"url": url, "payload": payload, "message_type": message_type}
+        )
+        return 200
+
+    monkeypatch.setattr(webhook_module, "send_webhook", fake_send_webhook)
+
+    spec = CommandSpec(
+        command_id="delegation",
+        command="",
+        requires_llm=False,
+        frequency_minutes=1,
+        priority=0,
+        metadata={},
+        title="Delegation",
+        command_type="delegation",
+    )
+    sched.store.add_command(spec)
+
+    # ensure webhook env is present so pre-dispatch path runs
+    monkeypatch.setenv("AMPA_DISCORD_WEBHOOK", "http://example.invalid/webhook")
+
+    # run start_command which triggers the delegation flow
+    sched.start_command(spec)
+
+    # verify opencode was invoked
+    assert any(c.startswith("opencode run") for c in calls)
+    # verify append_dispatch was called before opencode (assertion in fake_run_shell)
+    assert state["append_called"] is True
+    # verify a dispatch webhook was sent and included the dispatch id
+    assert any(c.get("message_type") == "dispatch" for c in captured["calls"]), (
+        "no dispatch webhook sent"
+    )
+    # find the dispatch call and verify content is the human-friendly message
+    dispatch_calls = [
+        c for c in captured["calls"] if c.get("message_type") == "dispatch"
+    ]
+    assert dispatch_calls, "no dispatch webhook recorded"
+    content = (dispatch_calls[-1].get("payload") or {}).get("content", "")
+    assert "Delegating" in content
+    assert "SA-TEST-123" in content


### PR DESCRIPTION
- **Add DEBUG verification and ERROR logging for heading-only AMPA audit comments**
- **Remove some elements of the workflow that have proven to be unecessary (milestones, PRD, testplan)**
- **Fix titling of child tasks**
- **SA-0MLDAXLDH1TQOYBT: add wl next selection**
- **audit is now a skill (see status skill)**
- **SA-0MLDAXLVE0JOZ0BH: add dry-run report and discord fallback**
- **SA-0MLDAXME718UNPR8, SA-0MLDIAVFT1805G2L: keep triage audits audit-only with templates and a real Discord summary**
- **Tighten up cleanup skill to do more by default.**
- **SA-0MLDLFVCC1SEYQA9: gate delegation with audit_only**
- **SA-0MLE6WOBV0P81E39: Add lightweight audit report**
- **Rename status skill to audit. Don't create a work item to track creating a plan.**
- **Remove confusion about parent/child blocking relationships**
- **Remove requirement to use non0existent --validate swiitch on create**
- **Audit is now a skill not a command**
- **Cleaner audit skill**
- **Don't create a work-item for intake work**
- **SA-0MLF2AJYM0ITPV9Q: add delegation output tests (in-progress, idle-with-candidate, wl show fallback)**
- **SA-0MLF2AJYM0ITPV9Q: print markdown directly after lead line for delegation output**
- **SA-0MLF2AJYM0ITPV9Q: concise in-progress delegation message; preserve header for compatibility; update tests**
- **SA-0MLF2AJYM0ITPV9Q: remove 'AMPA Delegation' header from concise in-progress message**
- **SA-0MLF2AJYM0ITPV9Q: remove 'AMPA Delegation' header from concise in-progress message; update tests**
- **WIP: unrelated local edits**
- **Guard against writing directly to local wrklog files.**
- **SA-0MLDICHPG1GR6J8G: Audit and robustify delegation and wl-next handling; prefer stage field over status**
- **SA-0MLG0I5RA1U14U75: pre-dispatch notification and tests; concise Discord message**
