### PR TITLE
SA-0MLHNNSY90TMYQUE: suppress triage audit no-candidate Discord

### DIFF
--- a/tests/test_startup_message.py
+++ b/tests/test_startup_message.py
@@ -24,7 +24,7 @@ def test_post_startup_message_uses_wl_status(tmp_path, monkeypatch):
     )
 
     # fake run_shell that returns wl status output on stdout
-    def fake_run_shell(cmd, shell, check, capture_output, text, cwd):
+    def fake_run_shell(cmd, shell, check, capture_output, text, cwd, timeout=None):
         return SimpleNamespace(
             returncode=0, stdout="WL status: all good\n1 in_progress\n", stderr=""
         )


### PR DESCRIPTION
## Summary
- stop triage-audit from posting the no-candidates Discord message
- run idle delegation after triage audits so summaries include delegation notes and dispatches occur
- adjust startup message test stub to accept timeout kwarg