### PR TITLE
Post waiting_for_input notifications (SA-0MLGZN2P0028GT0P)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -15,3 +15,23 @@ Environment variables:
 - `OPENCODE_BASE_URL` is required if you are not running the API on the default host.
 - `OPENCODE_PROVIDER_ID` (optional): default provider ID (defaults to `anthropic`)
 - `OPENCODE_MODEL_ID` (optional): default model ID (defaults to `claude-3-5-sonnet-20241022`)
+
+## waiting_for_input_notification.py
+
+Trigger a waiting_for_input notification to Discord/AMPA.
+
+```sh
+AMPA_DISCORD_WEBHOOK="https://discord.com/api/webhooks/..." \
+AMPA_RESPONDER_URL="http://localhost:8081/respond" \
+python examples/waiting_for_input_notification.py
+```
+
+Environment variables:
+
+- `AMPA_DISCORD_WEBHOOK` (required): Discord webhook for notifications.
+- `AMPA_RESPONDER_URL` (required): responder endpoint URL shown in the notification.
+- `AMPA_EXAMPLE_WORK_ITEM` (optional): work item id shown in the message (default `WL-EXAMPLE`).
+- `AMPA_TOOL_OUTPUT_DIR` (optional): override tool-output directory for pending prompt files.
+
+Verify in Discord/AMPA that the notification includes Session, Work item, Reason,
+Pending prompt file path, and Responder endpoint.

--- a/examples/waiting_for_input_notification.py
+++ b/examples/waiting_for_input_notification.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from ampa.conversation_manager import start_conversation
+
+
+def main() -> None:
+    session_id = f"s-wait-{uuid.uuid4().hex[:8]}"
+    work_item = os.getenv("AMPA_EXAMPLE_WORK_ITEM", "WL-EXAMPLE")
+    prompt = "Approve deploy?"
+    meta = start_conversation(session_id, prompt, {"work_item": work_item})
+
+    print("Started waiting-for-input example")
+    print(f"Session: {meta.get('session')}")
+    print(f"Work item: {meta.get('work_item')}")
+    print(f"Pending prompt file: {meta.get('prompt_file')}")
+    print("Check Discord/AMPA for the waiting_for_input notification.")
+
+
+if __name__ == "__main__":
+    main()

--- a/session_block.py
+++ b/session_block.py
@@ -106,8 +106,12 @@ def set_session_state(session_id: str, state: str) -> str:
 def _waiting_actions_text() -> str:
     return os.getenv(
         "AMPA_WAITING_FOR_INPUT_ACTIONS",
-        "Provide a response for the session prompt and resume the run.",
+        "Respond via the responder endpoint, or auto-accept/auto-decline.",
     )
+
+
+def _responder_endpoint_url() -> str:
+    return os.getenv("AMPA_RESPONDER_URL", "http://localhost:8081/respond")
 
 
 def _send_waiting_for_input_notification(metadata: Dict[str, Any]) -> Optional[int]:
@@ -129,12 +133,14 @@ def _send_waiting_for_input_notification(metadata: Dict[str, Any]) -> Optional[i
     prompt_file = metadata.get("prompt_file") or "(unknown)"
     pending_prompt_file = metadata.get("pending_prompt_file") or prompt_file
     tool_dir = metadata.get("tool_output_dir") or _tool_output_dir()
+    responder_url = _responder_endpoint_url()
     output = (
         "Session is waiting for input\n"
         f"Session: {session_id}\n"
         f"Work item: {work_item}\n"
-        f"Summary: {summary}\n"
+        f"Reason: {summary}\n"
         f"Actions: {actions}\n"
+        f"Responder endpoint: {responder_url}\n"
         f"Pending prompt file: {pending_prompt_file}\n"
         f"Tool output dir: {tool_dir}"
     )


### PR DESCRIPTION
## Summary
- include responder URL and CTA in waiting_for_input notifications
- add runnable example for notification payloads
- document example usage and env vars

## Testing
- pytest