### PR TITLE
SA-0MLUDW5F919NSIM4: Remove env var override and auto-init fallback from scheduler store

### DIFF
--- a/tests/test_scheduler_scoring.py
+++ b/tests/test_scheduler_scoring.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import json
 import os
 
 from ampa.scheduler import (
@@ -100,6 +101,7 @@ def test_global_rate_limiter_blocks_selection():
 def test_scheduler_runs_commands_from_start_cwd(tmp_path):
     now = dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc)
     store_path = tmp_path / "scheduler_store.json"
+    store_path.write_text(json.dumps({"commands": {}, "state": {}}))
     store = SchedulerStore(str(store_path))
     config = SchedulerConfig(
         poll_interval_seconds=10,

--- a/tests/test_scheduler_simulation.py
+++ b/tests/test_scheduler_simulation.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import json
 
 from ampa.scheduler import (
     CommandSpec,
@@ -30,6 +31,7 @@ def _seed_last_runs(scheduler: Scheduler, now: dt.datetime) -> None:
 def test_simulated_schedule_within_expected_deviation(tmp_path):
     now = dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc)
     store_path = tmp_path / "scheduler_store.json"
+    store_path.write_text(json.dumps({"commands": {}, "state": {}}))
     store = SchedulerStore(str(store_path))
     config = SchedulerConfig(
         poll_interval_seconds=10,


### PR DESCRIPTION
## Summary

- Simplify `SchedulerConfig.from_env()` to resolve only to the per-project path (`<cwd>/.worklog/ampa/scheduler_store.json`), removing the `AMPA_SCHEDULER_STORE` env var override and package-dir fallback
- `SchedulerStore` now raises `FileNotFoundError` with a helpful message instead of silently self-healing via auto-init from example or empty store fallback — enforces explicit store setup
- Remove `_initialize_from_example()` method entirely
- Add 4 unit tests covering the strict behavior (missing file, invalid JSON, local-path-only resolution, env var ignored)
- Update `test_scheduler_scoring` and `test_scheduler_simulation` to pre-create the store file

## Breaking Changes

- `AMPA_SCHEDULER_STORE` env var is no longer honored — store is always at `<projectRoot>/.worklog/ampa/scheduler_store.json`
- Store file must exist before starting the scheduler (no more auto-init from example)
- Missing or corrupt store files now raise exceptions instead of falling back to empty state

## Context

Follows up on SA-0MLU57S7D1KX8CU7 (per-project isolation), which introduced per-project-first resolution but kept backward compatibility. This commit removes the backward compat entirely, enforcing strict per-project-only behavior.

Work item: SA-0MLUDW5F919NSIM4
Parent: SA-0MLU57S7D1KX8CU7