### PR TITLE
SA-0MLXEM41U1VIK3TB: Extract delegation orchestration into ampa/delegation.py

### DIFF
--- a/ampa/delegation.py
+++ b/ampa/delegation.py
@@ -1,10 +1,12 @@
 """Delegation orchestration extracted from ampa.scheduler.
 
-Provides DelegationOrchestrator which encapsulates the delegation-specific
-flows: pre/post reports, idle delegation execution, report building and
-discord/webhook interactions. The implementation mirrors behavior formerly
-contained in ampa/scheduler.py so callers can opt-in by constructing and
-invoking this class from Scheduler.
+Provides ``DelegationOrchestrator`` which encapsulates the delegation-specific
+flows: pre/post reports, idle delegation execution, stale delegation recovery,
+report building and Discord/webhook interactions.
+
+Module-level helpers (``_content_hash``, ``_summarize_for_discord``,
+``_build_delegation_report``, etc.) are also defined here and re-exported by
+``ampa.scheduler`` for backward compatibility.
 
 This module intentionally keeps no external side-effects at import time so it
 is safe to import from tests and other modules.
@@ -12,6 +14,7 @@ is safe to import from tests and other modules.
 
 from __future__ import annotations
 
+import datetime as dt
 import hashlib
 import json
 import logging
@@ -21,16 +24,29 @@ from typing import Any, Callable, Dict, List, Optional
 
 from .engine.candidates import CandidateSelector
 from .engine.core import Engine, EngineResult, EngineStatus
-from . import webhook as webhook_module
-from . import selection
 
 LOG = logging.getLogger("ampa.delegation")
 
 
-def _utc_now():
-    import datetime as dt
+# ---------------------------------------------------------------------------
+# Utility / formatting helpers
+# ---------------------------------------------------------------------------
 
+
+def _utc_now() -> dt.datetime:
     return dt.datetime.now(dt.timezone.utc)
+
+
+def _from_iso(value: Optional[str]) -> Optional[dt.datetime]:
+    if not value:
+        return None
+    try:
+        v = value
+        if isinstance(v, str) and v.endswith("Z"):
+            v = v[:-1] + "+00:00"
+        return dt.datetime.fromisoformat(v)
+    except Exception:
+        return None
 
 
 def _trim_text(value: Optional[str]) -> str:
@@ -38,15 +54,25 @@ def _trim_text(value: Optional[str]) -> str:
 
 
 def _content_hash(text: Optional[str]) -> str:
+    """Return a SHA-256 hex digest of *text* for change detection.
+
+    Used to suppress duplicate delegation report Discord messages when the
+    report content has not changed since the previous run.
+    """
     return hashlib.sha256((text or "").encode("utf-8")).hexdigest()
 
 
 def _summarize_for_discord(text: Optional[str], max_chars: int = 1000) -> str:
+    """If text is longer than max_chars, call ``opencode run`` to produce a short summary.
+
+    Returns the original text on any failure.
+    """
     if not text:
         return ""
     try:
         if len(text) <= max_chars:
             return text
+        # avoid passing extremely large blobs to the CLI; cap input size
         cap = 20000
         input_text = text[:cap]
         cmd = [
@@ -61,15 +87,17 @@ def _summarize_for_discord(text: Optional[str], max_chars: int = 1000) -> str:
         if proc.returncode != 0:
             LOG.warning(
                 "opencode summarizer failed rc=%s stderr=%r",
-                proc.returncode,
-                proc.stderr,
+                getattr(proc, "returncode", None),
+                getattr(proc, "stderr", None),
             )
             return text
         summary = (proc.stdout or "").strip()
-        return summary or text
+        if not summary:
+            return text
+        return summary
     except Exception:
         LOG.exception("Failed to summarize content for Discord")
-        return text or ""
+        return text
 
 
 def _format_in_progress_items(text: str) -> List[str]:
@@ -107,19 +135,25 @@ def _format_candidate_line(candidate: Dict[str, Any]) -> str:
     return " ".join(parts)
 
 
-def _build_delegation_report(
+def _build_dry_run_report(
     *,
     in_progress_output: str,
     candidates: List[Dict[str, Any]],
     top_candidate: Optional[Dict[str, Any]],
 ) -> str:
+    # If there are in-progress items, produce a concise, operator-friendly
+    # message listing those items and skip the verbose candidate/top-candidate
+    # sections. This keeps the operator-facing output short when agents are
+    # actively working.
     in_progress_items = _format_in_progress_items(in_progress_output)
     if in_progress_items:
         lines: List[str] = ["Agents are currently busy with:"]
         for item in in_progress_items:
+            # match the visual style requested (em dash bullets)
             lines.append(f"── {item}")
         return "\n".join(lines)
 
+    # no in-progress items -> produce full report
     sections: List[str] = []
     sections.append("AMPA Delegation")
     sections.append("In-progress items:")
@@ -148,22 +182,85 @@ def _build_delegation_report(
     return "\n".join(sections)
 
 
+def _build_dry_run_discord_message(report: str) -> str:
+    summary = _summarize_for_discord(report, max_chars=1000)
+    if summary and summary.strip():
+        return summary
+    LOG.warning("Dry-run discord summary was empty; falling back to raw report content")
+    if report and report.strip():
+        return report.strip()
+    return "(no report details)"
+
+
+def _build_delegation_report(
+    *,
+    in_progress_output: str,
+    candidates: List[Dict[str, Any]],
+    top_candidate: Optional[Dict[str, Any]],
+) -> str:
+    return _build_dry_run_report(
+        in_progress_output=in_progress_output,
+        candidates=candidates,
+        top_candidate=top_candidate,
+    )
+
+
+def _build_delegation_discord_message(report: str) -> str:
+    return _build_dry_run_discord_message(report)
+
+
+# ---------------------------------------------------------------------------
+# DelegationOrchestrator
+# ---------------------------------------------------------------------------
+
+
 class DelegationOrchestrator:
+    """Encapsulates delegation orchestration formerly in ``Scheduler``.
+
+    Accepts the same infrastructure dependencies that the scheduler used
+    (``store``, ``run_shell``, ``command_cwd``, ``engine``,
+    ``candidate_selector``) and exposes a small public API:
+
+    * ``execute(spec, run)`` — full delegation flow called from
+      ``Scheduler.start_command()``
+    * ``run_idle_delegation(audit_only, spec)`` — engine wrapper used by
+      triage-audit and the delegation flow
+    * ``run_delegation_report(spec)`` — human-readable report generation
+    * ``recover_stale_delegations()`` — stale delegation watchdog
+    """
+
     def __init__(
         self,
-        store,
+        store: Any,
         run_shell: Callable[..., subprocess.CompletedProcess],
         command_cwd: str,
         engine: Optional[Engine] = None,
         candidate_selector: Optional[CandidateSelector] = None,
+        # Lazy imports to avoid circular dependency at module load time.
+        # Callers pass these modules/functions so this module does not import
+        # ``ampa.webhook`` or ``ampa.selection`` directly.
+        webhook_module: Any = None,
+        selection_module: Any = None,
     ) -> None:
         self.store = store
         self.run_shell = run_shell
         self.command_cwd = command_cwd
         self.engine = engine
         self._candidate_selector = candidate_selector
+        self._webhook_module = webhook_module
+        self._selection_module = selection_module
+
+    # -- report dedup -------------------------------------------------------
 
     def _is_delegation_report_changed(self, command_id: str, report_text: str) -> bool:
+        """Check whether the delegation report content has changed.
+
+        Compares a SHA-256 hash of *report_text* against the hash stored in the
+        scheduler state under ``last_delegation_report_hash``.  Returns True if
+        the content differs (or no previous hash exists) and updates the stored
+        hash.  Returns False when the content is identical to suppress duplicate
+        Discord messages.
+        """
         new_hash = _content_hash(report_text)
         state = self.store.get_state(command_id)
         old_hash = state.get("last_delegation_report_hash")
@@ -173,12 +270,208 @@ class DelegationOrchestrator:
                 new_hash[:12],
             )
             return False
+        # Content changed – persist the new hash
         state["last_delegation_report_hash"] = new_hash
         self.store.update_state(command_id, state)
-        LOG.info("Delegation report changed (new=%s)", new_hash[:12])
+        LOG.info(
+            "Delegation report changed (old=%s new=%s); sending Discord webhook",
+            (old_hash or "(none)")[:12],
+            new_hash[:12],
+        )
         return True
 
-    def _run_delegation_report(self) -> Optional[str]:
+    # -- inspect idle delegation --------------------------------------------
+
+    def _inspect_idle_delegation(self) -> Dict[str, Any]:
+        """Lightweight pre-flight check for delegation state.
+
+        Uses the engine's ``CandidateSelector`` to determine whether agents
+        are idle and whether there is a candidate to delegate.  Returns a
+        status dict consumed by ``execute()`` to decide what to print
+        and whether to proceed with full engine delegation.
+
+        Possible status values:
+        - ``"in_progress"`` — work is already in progress (items in dict)
+        - ``"idle_no_candidate"`` — idle but no actionable candidates
+        - ``"idle_with_candidate"`` — idle with a selected candidate (raw dict)
+        - ``"error"`` — the pre-flight check itself failed
+        """
+        selector = self._candidate_selector
+        if selector is None:
+            LOG.warning("No candidate selector available for inspect")
+            return {"status": "error", "reason": "no_candidate_selector"}
+
+        try:
+            result = selector.select()
+        except Exception:
+            LOG.exception("CandidateSelector.select() raised during inspect")
+            return {"status": "error", "reason": "selector_exception"}
+
+        # Global rejections indicate in-progress items or fetch failures
+        if result.global_rejections:
+            for reason in result.global_rejections:
+                if "in-progress" in reason.lower() or "in_progress" in reason.lower():
+                    # Convert candidates back to raw dicts for the items list
+                    items = (
+                        [c.raw for c in result.candidates] if result.candidates else []
+                    )
+                    return {"status": "in_progress", "items": items}
+            # Other global rejection (e.g. fetch failure)
+            return {
+                "status": "error",
+                "reason": "; ".join(result.global_rejections),
+            }
+
+        if result.selected is None:
+            return {"status": "idle_no_candidate", "payload": None}
+
+        return {
+            "status": "idle_with_candidate",
+            "candidate": result.selected.raw,
+            "candidate_id": result.selected.id,
+            "candidate_title": result.selected.title,
+        }
+
+    # -- run idle delegation (engine wrapper) -------------------------------
+
+    def run_idle_delegation(
+        self, *, audit_only: bool, spec: Any = None
+    ) -> Dict[str, Any]:
+        """Attempt to dispatch work when agents are idle.
+
+        Delegates all candidate selection, invariant evaluation, state
+        transitions, and dispatch to the engine.  Converts the EngineResult
+        back into the dict format expected by callers.
+
+        Returns a dict with at least the following keys:
+        - note: human-readable summary
+        - dispatched: bool (True if a delegation was dispatched)
+        - rejected: list of rejected candidate summaries (may be empty)
+        - idle_webhook_sent: bool (True if a detailed idle webhook was posted)
+        - delegate_info: optional dict with dispatch details when dispatched
+        """
+        assert self.engine is not None  # guaranteed by caller
+
+        if audit_only:
+            return {
+                "note": "Delegation: skipped (audit_only)",
+                "dispatched": False,
+                "rejected": [],
+                "idle_webhook_sent": False,
+            }
+
+        try:
+            result = self.engine.process_delegation()
+        except Exception:
+            LOG.exception("Engine process_delegation raised an exception")
+            return {
+                "note": "Delegation: engine error",
+                "dispatched": False,
+                "rejected": [],
+                "idle_webhook_sent": False,
+                "error": "engine exception",
+            }
+
+        # Convert EngineResult to dict format.
+        status = result.status
+
+        if status == EngineStatus.SUCCESS:
+            action = result.action or "unknown"
+            wid = result.work_item_id or "?"
+            delegate_title = ""
+            if result.candidate_result and result.candidate_result.selected:
+                delegate_title = result.candidate_result.selected.title
+            delegate_info: Dict[str, Any] = {
+                "action": action,
+                "id": wid,
+                "title": delegate_title,
+                "stdout": "",
+                "stderr": "",
+            }
+            if result.dispatch_result:
+                delegate_info["pid"] = result.dispatch_result.pid
+            return {
+                "note": f"Delegation: dispatched {action} {wid}",
+                "dispatched": True,
+                "delegate_info": delegate_info,
+                "rejected": self._engine_rejections(result),
+                "idle_webhook_sent": False,
+            }
+
+        if status == EngineStatus.NO_CANDIDATES:
+            # The engine already sent a Discord notification via its notifier.
+            return {
+                "note": "Delegation: skipped (no wl next candidates)",
+                "dispatched": False,
+                "rejected": self._engine_rejections(result),
+                "idle_webhook_sent": True,
+            }
+
+        if status == EngineStatus.SKIPPED:
+            return {
+                "note": f"Delegation: skipped ({result.reason})",
+                "dispatched": False,
+                "rejected": [],
+                "idle_webhook_sent": False,
+            }
+
+        if status in (
+            EngineStatus.REJECTED,
+            EngineStatus.INVARIANT_FAILED,
+        ):
+            return {
+                "note": f"Delegation: blocked ({result.reason})",
+                "dispatched": False,
+                "rejected": self._engine_rejections(result),
+                "idle_webhook_sent": False,
+            }
+
+        if status == EngineStatus.DISPATCH_FAILED:
+            return {
+                "note": f"Delegation: failed ({result.reason})",
+                "dispatched": False,
+                "rejected": self._engine_rejections(result),
+                "idle_webhook_sent": False,
+                "error": result.reason,
+            }
+
+        # ERROR or any other unexpected status
+        return {
+            "note": f"Delegation: engine error ({result.reason})",
+            "dispatched": False,
+            "rejected": self._engine_rejections(result),
+            "idle_webhook_sent": False,
+            "error": result.reason,
+        }
+
+    @staticmethod
+    def _engine_rejections(result: EngineResult) -> List[Dict[str, str]]:
+        """Extract rejected-candidate summaries from an EngineResult for
+        backward compatibility with the legacy delegation dict format."""
+        rejected: List[Dict[str, str]] = []
+        cr = getattr(result, "candidate_result", None)
+        if cr is None:
+            return rejected
+        for rej in getattr(cr, "rejections", ()):
+            c = getattr(rej, "candidate", None)
+            rejected.append(
+                {
+                    "id": getattr(c, "id", "?") if c else "?",
+                    "title": getattr(c, "title", "(unknown)") if c else "(unknown)",
+                    "reason": getattr(rej, "reason", "rejected"),
+                }
+            )
+        return rejected
+
+    # -- delegation report generation ---------------------------------------
+
+    def run_delegation_report(self, spec: Any = None) -> Optional[str]:
+        """Generate a human-readable delegation report.
+
+        Queries ``wl in_progress`` and candidate selection to build a report
+        suitable for operator display or Discord posting.
+        """
+
         def _call(cmd: str) -> subprocess.CompletedProcess:
             LOG.debug("Running shell (delegation): %s", cmd)
             return self.run_shell(
@@ -197,6 +490,13 @@ class DelegationOrchestrator:
         if proc.stderr and not in_progress_text:
             in_progress_text += proc.stderr
 
+        selection = self._selection_module
+        if selection is None:
+            try:
+                from . import selection
+            except Exception:
+                import ampa.selection as selection  # type: ignore[no-redef]
+
         candidates, _payload = selection.fetch_candidates(
             run_shell=self.run_shell, command_cwd=self.command_cwd
         )
@@ -209,188 +509,349 @@ class DelegationOrchestrator:
         )
         return report
 
-    def _run_idle_delegation(self, audit_only: bool) -> Dict[str, Any]:
-        if audit_only:
-            return {
-                "note": "Delegation: skipped (audit_only)",
-                "dispatched": False,
-                "rejected": [],
-                "idle_webhook_sent": False,
-            }
-        if not self.engine:
-            raise RuntimeError("Engine not configured for delegation")
-        try:
-            result = self.engine.process_delegation()
-        except Exception:
-            LOG.exception("Engine process_delegation raised an exception")
-            return {
-                "note": "Delegation: engine error",
-                "dispatched": False,
-                "rejected": [],
-                "idle_webhook_sent": False,
-                "error": "engine exception",
-            }
+    # -- stale delegation watchdog ------------------------------------------
 
-        status = result.status
-        if status == EngineStatus.SUCCESS:
-            action = result.action or "unknown"
-            wid = result.work_item_id or "?"
-            delegate_title = ""
-            if result.candidate_result and result.candidate_result.selected:
-                delegate_title = result.candidate_result.selected.title
-            delegate_info = {"action": action, "id": wid, "title": delegate_title}
-            if result.dispatch_result:
-                delegate_info["pid"] = result.dispatch_result.pid
-            return {
-                "note": f"Delegation: dispatched {action} {wid}",
-                "dispatched": True,
-                "delegate_info": delegate_info,
-                "rejected": self._engine_rejections(result),
-                "idle_webhook_sent": False,
-            }
+    def recover_stale_delegations(self) -> List[Dict[str, Any]]:
+        """Detect work items stuck in ``delegated`` stage and reset them.
 
-        if status == EngineStatus.NO_CANDIDATES:
-            return {
-                "note": "Delegation: skipped (no wl next candidates)",
-                "dispatched": False,
-                "rejected": self._engine_rejections(result),
-                "idle_webhook_sent": True,
-            }
+        When an ``opencode run`` agent process crashes or hangs without
+        updating the work item, the item remains in
+        ``(in_progress, delegated)`` forever, blocking all future
+        delegations via the ``no_in_progress_items`` invariant.
 
-        if status == EngineStatus.SKIPPED:
-            return {
-                "note": f"Delegation: skipped ({result.reason})",
-                "dispatched": False,
-                "rejected": [],
-                "idle_webhook_sent": False,
-            }
+        This method:
 
-        if status in (EngineStatus.REJECTED, EngineStatus.INVARIANT_FAILED):
-            return {
-                "note": f"Delegation: blocked ({result.reason})",
-                "dispatched": False,
-                "rejected": self._engine_rejections(result),
-                "idle_webhook_sent": False,
-            }
+        1. Queries ``wl in_progress --json`` for items with
+           ``stage == "delegated"``.
+        2. Checks each item's ``updatedAt`` against
+           ``AMPA_STALE_DELEGATION_THRESHOLD_SECONDS`` (default 7200s).
+        3. Resets stale items to ``(open, plan_complete)`` so delegation
+           can be retried on the next cycle.
+        4. Posts a ``wl comment`` documenting the recovery.
+        5. Sends a Discord notification.
 
-        if status == EngineStatus.DISPATCH_FAILED:
-            return {
-                "note": f"Delegation: failed ({result.reason})",
-                "dispatched": False,
-                "rejected": self._engine_rejections(result),
-                "idle_webhook_sent": False,
-                "error": result.reason,
-            }
-
-        return {
-            "note": f"Delegation: engine error ({result.reason})",
-            "dispatched": False,
-            "rejected": self._engine_rejections(result),
-            "idle_webhook_sent": False,
-            "error": result.reason,
-        }
-
-    @staticmethod
-    def _engine_rejections(result: EngineResult) -> List[Dict[str, str]]:
-        rejected: List[Dict[str, str]] = []
-        cr = getattr(result, "candidate_result", None)
-        if cr is None:
-            return rejected
-        for rej in getattr(cr, "rejections", ()):
-            c = getattr(rej, "candidate", None)
-            rejected.append(
-                {
-                    "id": getattr(c, "id", "?") if c else "?",
-                    "title": getattr(c, "title", "(unknown)") if c else "(unknown)",
-                    "reason": getattr(rej, "reason", "rejected"),
-                }
-            )
-        return rejected
-
-    def execute(self, spec: Any, audit_only: bool = False) -> Dict[str, Any]:
-        """Run delegation flow for a delegation CommandSpec.
-
-        Returns the structured result dict used by Scheduler.start_command.
+        Returns a list of dicts describing recovered items (empty list
+        when nothing was stale).
         """
-        # Pre-dispatch report when there is no imminent dispatch (caller can
-        # decide when to call execute to match prior behaviour).
-        report = None
         try:
-            report = self._run_delegation_report()
+            thresh_raw = os.getenv("AMPA_STALE_DELEGATION_THRESHOLD_SECONDS", "7200")
+            try:
+                threshold = int(thresh_raw)
+            except Exception:
+                threshold = 7200
         except Exception:
-            LOG.exception("Delegation report generation failed")
+            threshold = 7200
 
-        sent_pre_report = False
-        if report:
-            LOG.info("Pre-dispatch delegation report generated (len=%d)", len(report))
-            sent_pre_report = True
+        now = _utc_now()
+        recovered: List[Dict[str, Any]] = []
+
+        # 1. Query in-progress items
+        try:
+            proc = self.run_shell(
+                "wl in_progress --json",
+                shell=True,
+                check=False,
+                capture_output=True,
+                text=True,
+                cwd=self.command_cwd,
+            )
+        except Exception:
+            LOG.exception("Stale delegation watchdog: wl in_progress failed")
+            return recovered
+
+        if proc.returncode != 0:
+            LOG.warning(
+                "Stale delegation watchdog: wl in_progress returned rc=%s",
+                proc.returncode,
+            )
+            return recovered
+
+        # Parse items
+        try:
+            raw = json.loads(proc.stdout or "null")
+        except Exception:
+            LOG.exception("Stale delegation watchdog: failed to parse wl in_progress")
+            return recovered
+
+        items: List[Dict[str, Any]] = []
+        if isinstance(raw, list):
+            items = [it for it in raw if isinstance(it, dict)]
+        elif isinstance(raw, dict):
+            for key in ("workItems", "work_items", "items", "data"):
+                val = raw.get(key)
+                if isinstance(val, list):
+                    items = [it for it in val if isinstance(it, dict)]
+                    break
+
+        # 2. Filter to delegated items that are stale
+        for item in items:
+            try:
+                stage = item.get("stage") or item.get("currentStage") or ""
+                if stage != "delegated":
+                    continue
+
+                work_id = (
+                    item.get("id") or item.get("work_item_id") or item.get("work_item")
+                )
+                if not work_id:
+                    continue
+
+                # Determine age from updatedAt
+                updated_str = None
+                for k in (
+                    "updated_at",
+                    "updatedAt",
+                    "last_updated_at",
+                    "updated_ts",
+                    "updated",
+                ):
+                    v = item.get(k)
+                    if v:
+                        updated_str = v
+                        break
+
+                updated_dt = _from_iso(updated_str) if updated_str else None
+                age_s = (
+                    int((now - updated_dt).total_seconds())
+                    if updated_dt is not None
+                    else None
+                )
+
+                if age_s is None or age_s <= threshold:
+                    LOG.debug(
+                        "Stale delegation watchdog: %s age=%s <= threshold=%s, skipping",
+                        work_id,
+                        age_s,
+                        threshold,
+                    )
+                    continue
+
+                # 3. Reset the work item to (open, plan_complete)
+                LOG.warning(
+                    "Stale delegation watchdog: recovering %s (age=%ss, threshold=%ss)",
+                    work_id,
+                    age_s,
+                    threshold,
+                )
+                title = item.get("title", "(unknown)")
+                reset_proc = self.run_shell(
+                    f"wl update {work_id} --status open --stage plan_complete --json",
+                    shell=True,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    cwd=self.command_cwd,
+                )
+                if reset_proc.returncode != 0:
+                    LOG.error(
+                        "Stale delegation watchdog: failed to reset %s rc=%s stderr=%r",
+                        work_id,
+                        reset_proc.returncode,
+                        (reset_proc.stderr or "")[:512],
+                    )
+                    continue
+
+                # 4. Post a wl comment documenting the recovery
+                comment_text = (
+                    f"[watchdog] Stale delegation recovery: this item was stuck in "
+                    f"(in_progress, delegated) for {age_s}s "
+                    f"(threshold: {threshold}s). "
+                    f"Reset to (open, plan_complete) for re-delegation. "
+                    f"The previous agent session likely crashed or hung "
+                    f"without updating the work item."
+                )
+                try:
+                    self.run_shell(
+                        f'wl comment add {work_id} --comment "{comment_text}" '
+                        f"--author ampa-watchdog --json",
+                        shell=True,
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                        cwd=self.command_cwd,
+                    )
+                except Exception:
+                    LOG.exception(
+                        "Stale delegation watchdog: failed to post comment on %s",
+                        work_id,
+                    )
+
+                recovery_info = {
+                    "work_item_id": str(work_id),
+                    "title": title,
+                    "age_seconds": age_s,
+                    "threshold_seconds": threshold,
+                    "reset_to": "open/plan_complete",
+                }
+                recovered.append(recovery_info)
+                LOG.info(
+                    "Stale delegation watchdog: recovered %s (%s)",
+                    work_id,
+                    title,
+                )
+
+            except Exception:
+                LOG.exception(
+                    "Stale delegation watchdog: error processing item %s",
+                    item.get("id", "?"),
+                )
+
+        # 5. Discord notification (batched)
+        if recovered:
             try:
                 webhook = os.getenv("AMPA_DISCORD_WEBHOOK")
-                if webhook and self._is_delegation_report_changed(
-                    spec.command_id, report
-                ):
-                    message = _summarize_for_discord(report, max_chars=1000)
-                    payload = webhook_module.build_command_payload(
+                wh_mod = self._webhook_module
+                if webhook and wh_mod is not None:
+                    lines = [
+                        f"Stale delegation watchdog recovered {len(recovered)} item(s):"
+                    ]
+                    for info in recovered:
+                        lines.append(
+                            f"- {info['work_item_id']}: {info['title']} "
+                            f"(stale {info['age_seconds']}s, reset to {info['reset_to']})"
+                        )
+                    msg = "\n".join(lines)
+                    payload = wh_mod.build_command_payload(
                         os.uname().nodename,
-                        _utc_now().isoformat(),
-                        spec.command_id,
-                        message,
+                        now.isoformat(),
+                        "stale_delegation_watchdog",
+                        msg,
                         0,
-                        title=(
-                            spec.title
-                            or spec.metadata.get("discord_label")
-                            or "Delegation Report"
-                        ),
+                        title="Stale Delegation Recovery",
                     )
-                    webhook_module.send_webhook(
-                        webhook, payload, message_type="command"
-                    )
+                    wh_mod.send_webhook(webhook, payload, message_type="warning")
             except Exception:
-                LOG.exception("Delegation discord notification failed")
+                LOG.exception(
+                    "Stale delegation watchdog: failed to send Discord notification"
+                )
 
-        # run idle delegation
-        inspect_status = None
-        try:
-            # Lightweight pre-flight: use candidate_selector when available
-            if self._candidate_selector:
-                sel = self._candidate_selector.select()
-                if sel.global_rejections:
-                    for r in sel.global_rejections:
-                        if "in-progress" in r.lower() or "in_progress" in r.lower():
-                            inspect_status = "in_progress"
-                            break
-                if inspect_status is None:
-                    if sel.selected is None:
-                        inspect_status = "idle_no_candidate"
-                    else:
-                        inspect_status = "idle_with_candidate"
-            else:
-                inspect_status = None
-        except Exception:
-            LOG.exception("CandidateSelector.select() raised during inspect")
-            inspect_status = None
+        return recovered
 
-        if inspect_status == "in_progress":
+    # -- main delegation flow -----------------------------------------------
+
+    def execute(self, spec: Any, run: Any, output: Optional[str]) -> Any:
+        """Run the full delegation flow for a delegation CommandSpec.
+
+        This replaces the ``if spec.command_type == "delegation":`` branch
+        that was formerly in ``Scheduler.start_command()``.
+
+        Parameters
+        ----------
+        spec : CommandSpec
+            The delegation command spec.
+        run : RunResult
+            The RunResult produced by the executor.
+        output : str or None
+            Raw output captured from the executor.
+
+        Returns
+        -------
+        RunResult
+            An updated RunResult with delegation metadata attached.
+        """
+        # Avoid importing at module level to prevent circular imports.
+        # These are only needed when execute() is called.
+        from .scheduler import _bool_meta, CommandRunResult, RunResult
+
+        wh_mod = self._webhook_module
+
+        LOG.info(
+            "Handling delegation command: %s (audit_only=%s)",
+            spec.command_id,
+            _bool_meta(spec.metadata.get("audit_only")),
+        )
+        # Inspect current state first. If there is a candidate that will be
+        # dispatched we want to avoid sending the pre-dispatch report to
+        # Discord (otherwise operators see two nearly-identical messages).
+        audit_only = _bool_meta(spec.metadata.get("audit_only"))
+        inspect = self._inspect_idle_delegation()
+        status = inspect.get("status")
+
+        # Only generate and send a pre-dispatch report when we are not
+        # about to dispatch a candidate. If we will dispatch (status
+        # == 'idle_with_candidate' and audit_only is false) skip the
+        # pre-report; a post-dispatch report will be sent after the
+        # delegation completes.
+        report = None
+        sent_pre_report = False
+        if audit_only or status != "idle_with_candidate":
+            try:
+                LOG.info(
+                    "Generating pre-dispatch delegation report for %s",
+                    spec.command_id,
+                )
+                report = self.run_delegation_report(spec)
+            except Exception:
+                LOG.exception("Delegation report generation failed")
+            if report:
+                LOG.info(
+                    "Pre-dispatch delegation report generated (len=%d)", len(report)
+                )
+                output = report
+                # A pre-report was generated so the idle-no-candidate
+                # fallback webhook should not fire regardless of whether
+                # the dedup check suppresses this particular send.
+                sent_pre_report = True
+                try:
+                    webhook = os.getenv("AMPA_DISCORD_WEBHOOK")
+                    if webhook and self._is_delegation_report_changed(
+                        spec.command_id, report
+                    ):
+                        message = _build_delegation_discord_message(report)
+                        payload = wh_mod.build_command_payload(
+                            os.uname().nodename,
+                            run.end_ts.isoformat(),
+                            spec.command_id,
+                            message,
+                            run.exit_code,
+                            title=(
+                                spec.title
+                                or spec.metadata.get("discord_label")
+                                or "Delegation Report"
+                            ),
+                        )
+                        wh_mod.send_webhook(webhook, payload, message_type="command")
+                        LOG.info("Sent pre-dispatch webhook for %s", spec.command_id)
+                except Exception:
+                    LOG.exception("Delegation discord notification failed")
+        # if we skipped creating a pre-report, 'report' stays None and
+        # 'output' remains as previously (possibly None). Proceed to
+        # handling the inspected status below.
+
+        # ensure status variable is available below
+        # status may already be set above; if not, extract it
+        status = inspect.get("status")
+        if status == "in_progress":
+            print("There is work in progress and thus no new work will be delegated.")
             LOG.info("Delegation skipped because work is in-progress")
-            return {
+            result = {
                 "note": "Delegation: skipped (in_progress items)",
                 "dispatched": False,
                 "rejected": [],
                 "idle_webhook_sent": False,
             }
-
-        if inspect_status == "idle_no_candidate":
+        elif status == "idle_no_candidate":
+            # More descriptive idle message for operators
             idle_msg = "Agents are idle: no actionable items found"
+            print(idle_msg)
             LOG.info("Delegation: idle_no_candidate - %s", idle_msg)
+            result = {
+                "note": "Delegation: skipped (no actionable candidates)",
+                "dispatched": False,
+                "rejected": [],
+                "idle_webhook_sent": False,
+            }
+            # If we did not already send a detailed pre-report, send a
+            # short webhook message so Discord reflects the idle state.
             if not sent_pre_report:
                 try:
                     webhook = os.getenv("AMPA_DISCORD_WEBHOOK")
                     if webhook and self._is_delegation_report_changed(
                         spec.command_id, idle_msg
                     ):
-                        payload = webhook_module.build_command_payload(
+                        payload = wh_mod.build_command_payload(
                             os.uname().nodename,
-                            _utc_now().isoformat(),
+                            run.end_ts.isoformat(),
                             spec.command_id,
                             idle_msg,
                             0,
@@ -400,53 +861,139 @@ class DelegationOrchestrator:
                                 or "Delegation Report"
                             ),
                         )
-                        webhook_module.send_webhook(
-                            webhook, payload, message_type="command"
-                        )
-                        return {
-                            "note": "Delegation: skipped (no actionable candidates)",
-                            "dispatched": False,
-                            "rejected": [],
-                            "idle_webhook_sent": True,
-                        }
+                        wh_mod.send_webhook(webhook, payload, message_type="command")
                 except Exception:
                     LOG.exception("Failed to send idle-state webhook")
-            return {
-                "note": "Delegation: skipped (no actionable candidates)",
+        elif status == "idle_with_candidate":
+            delegate_id = inspect.get("candidate_id")
+            delegate_title = inspect.get("candidate_title") or "(no title)"
+            print(f"Starting work on: {delegate_title} - {delegate_id or '?'}")
+            result = self.run_idle_delegation(audit_only=audit_only, spec=spec)
+            # If delegation did not dispatch anything, ensure operators see
+            # an idle-state message unless a detailed idle webhook was
+            # already sent by the delegation routine.
+            try:
+                note = result.get("note") if isinstance(result, dict) else str(result)
+                dispatched = bool(
+                    result.get("dispatched") if isinstance(result, dict) else False
+                )
+                idle_webhook_sent = bool(
+                    result.get("idle_webhook_sent")
+                    if isinstance(result, dict)
+                    else False
+                )
+                if not dispatched:
+                    idle_msg = "Agents are idle: no actionable items found"
+                    print(idle_msg)
+                    # If we didn't already send a detailed pre-report or the
+                    # delegation routine didn't post its detailed idle webhook,
+                    # send a short idle notification so Discord reflects the
+                    # current idle state.
+                    if not sent_pre_report and not idle_webhook_sent:
+                        webhook = os.getenv("AMPA_DISCORD_WEBHOOK")
+                        if webhook and self._is_delegation_report_changed(
+                            spec.command_id, idle_msg
+                        ):
+                            try:
+                                payload = wh_mod.build_command_payload(
+                                    os.uname().nodename,
+                                    run.end_ts.isoformat(),
+                                    spec.command_id,
+                                    idle_msg,
+                                    0,
+                                    title=(
+                                        spec.title
+                                        or spec.metadata.get("discord_label")
+                                        or "Delegation Report"
+                                    ),
+                                )
+                                wh_mod.send_webhook(
+                                    webhook, payload, message_type="command"
+                                )
+                            except Exception:
+                                LOG.exception("Failed to send idle-state webhook")
+            except Exception:
+                LOG.exception("Failed to handle no-actionable-candidates path")
+        else:
+            print("There is no candidate to delegate.")
+            result = {
+                "note": "Delegation: skipped (in_progress check failed)",
                 "dispatched": False,
                 "rejected": [],
                 "idle_webhook_sent": False,
             }
-
-        # otherwise attempt real delegation
-        result = self._run_idle_delegation(audit_only=audit_only)
-
-        # if dispatched, send post-delegation report
+        # Send a follow-up Discord notification when a delegation action
+        # was actually dispatched so the Discord report reflects the
+        # resulting state instead of the pre-delegation dry-run.
         try:
-            if result.get("dispatched"):
-                post_report = self._run_delegation_report()
-                if post_report:
-                    # update stored hash so next cycle compares against post state
-                    self._is_delegation_report_changed(spec.command_id, post_report)
-                    post_message = _summarize_for_discord(post_report, max_chars=1000)
-                    webhook = os.getenv("AMPA_DISCORD_WEBHOOK")
-                    if webhook:
-                        payload = webhook_module.build_command_payload(
-                            os.uname().nodename,
-                            _utc_now().isoformat(),
-                            spec.command_id,
-                            post_message,
-                            0,
-                            title=(
-                                spec.title
-                                or spec.metadata.get("discord_label")
-                                or "Delegation Report"
-                            ),
-                        )
-                        webhook_module.send_webhook(
-                            webhook, payload, message_type="command"
-                        )
+            webhook = os.getenv("AMPA_DISCORD_WEBHOOK")
+            if webhook:
+                # If something was dispatched, re-run the report to capture
+                # the post-dispatch state and post that as an update.
+                dispatched_flag = False
+                if isinstance(result, dict):
+                    dispatched_flag = bool(result.get("dispatched"))
+                if dispatched_flag:
+                    try:
+                        post_report = self.run_delegation_report(spec)
+                        if post_report:
+                            # Update the stored hash so the next cycle
+                            # compares against this post-dispatch state
+                            # rather than the stale pre-dispatch content.
+                            self._is_delegation_report_changed(
+                                spec.command_id, post_report
+                            )
+                            post_message = _build_delegation_discord_message(
+                                post_report
+                            )
+                            payload = wh_mod.build_command_payload(
+                                os.uname().nodename,
+                                run.end_ts.isoformat(),
+                                spec.command_id,
+                                post_message,
+                                run.exit_code,
+                                title=(
+                                    spec.title
+                                    or spec.metadata.get("discord_label")
+                                    or "Delegation Report"
+                                ),
+                            )
+                            wh_mod.send_webhook(
+                                webhook, payload, message_type="command"
+                            )
+                    except Exception:
+                        LOG.exception("Failed to send post-delegation webhook")
         except Exception:
-            LOG.exception("Failed to send post-delegation webhook")
+            LOG.exception("Delegation webhook follow-up failed")
 
-        return result
+        # Use the structured result.note when available
+        summary_note = None
+        if isinstance(result, dict):
+            summary_note = result.get("note")
+        else:
+            try:
+                summary_note = str(result)
+            except Exception:
+                summary_note = None
+        LOG.info("Delegation summary: %s", summary_note)
+        # Attach delegation result as metadata on the RunResult so
+        # formatters can include the action taken.
+        delegation_meta: Dict[str, Any] = {}
+        if isinstance(result, dict):
+            delegation_meta["delegation"] = result
+        if isinstance(run, CommandRunResult):
+            run = CommandRunResult(
+                start_ts=run.start_ts,
+                end_ts=run.end_ts,
+                exit_code=run.exit_code,
+                output=output or run.output,
+                metadata=delegation_meta or None,
+            )
+        else:
+            run = RunResult(
+                start_ts=run.start_ts,
+                end_ts=run.end_ts,
+                exit_code=run.exit_code,
+                metadata=delegation_meta or None,
+            )
+        return run

--- a/ampa/scheduler.py
+++ b/ampa/scheduler.py
@@ -332,57 +332,6 @@ def default_llm_probe(url: str) -> bool:
         return False
 
 
-def _summarize_for_discord(text: Optional[str], max_chars: int = 1000) -> str:
-    """If text is longer than max_chars, call `opencode run` to produce a short summary.
-
-    Returns the original text on any failure.
-    """
-    if not text:
-        return ""
-    try:
-        if len(text) <= max_chars:
-            return text
-        # avoid passing extremely large blobs to the CLI; cap input size
-        cap = 20000
-        input_text = text[:cap]
-        cmd = [
-            "opencode",
-            "run",
-            f"summarize this content in under {max_chars} characters: {input_text}",
-        ]
-        LOG.info("Summarizing content for Discord (len=%d) via opencode", len(text))
-        proc = subprocess.run(
-            cmd, check=False, capture_output=True, text=True, timeout=30
-        )
-        if proc.returncode != 0:
-            LOG.warning(
-                "opencode summarizer failed rc=%s stderr=%r",
-                getattr(proc, "returncode", None),
-                getattr(proc, "stderr", None),
-            )
-            return text
-        summary = (proc.stdout or "").strip()
-        if not summary:
-            return text
-        return summary
-    except Exception:
-        LOG.exception("Failed to summarize content for Discord")
-        return text
-
-
-def _trim_text(value: Optional[str]) -> str:
-    return value.strip() if value else ""
-
-
-def _content_hash(text: Optional[str]) -> str:
-    """Return a SHA-256 hex digest of *text* for change detection.
-
-    Used to suppress duplicate delegation report Discord messages when the
-    report content has not changed since the previous run.
-    """
-    return hashlib.sha256((text or "").encode("utf-8")).hexdigest()
-
-
 def _bool_meta(value: Any) -> bool:
     if isinstance(value, bool):
         return value
@@ -391,113 +340,22 @@ def _bool_meta(value: Any) -> bool:
     return str(value).strip().lower() in ("1", "true", "yes", "y", "on")
 
 
-def _format_in_progress_items(text: str) -> List[str]:
-    lines = [line.rstrip() for line in (text or "").splitlines()]
-    items: List[str] = []
-    for line in lines:
-        stripped = line.strip()
-        if not stripped:
-            continue
-        if "- SA-" not in stripped:
-            continue
-        cleaned = stripped.lstrip("├└│ ")
-        items.append(cleaned)
-    if not items:
-        for line in lines:
-            stripped = line.strip()
-            if stripped:
-                items.append(stripped)
-    return items
-
-
-def _format_candidate_line(candidate: Dict[str, Any]) -> str:
-    work_id = str(candidate.get("id") or "?")
-    title = candidate.get("title") or candidate.get("name") or "(no title)"
-    status = candidate.get("status") or candidate.get("stage") or ""
-    priority = candidate.get("priority")
-    parts = [f"{title} - {work_id}"]
-    meta: List[str] = []
-    if status:
-        meta.append(f"status: {status}")
-    if priority is not None:
-        meta.append(f"priority: {priority}")
-    if meta:
-        parts.append("(" + ", ".join(meta) + ")")
-    return " ".join(parts)
-
-
-def _build_dry_run_report(
-    *,
-    in_progress_output: str,
-    candidates: List[Dict[str, Any]],
-    top_candidate: Optional[Dict[str, Any]],
-) -> str:
-    # If there are in-progress items, produce a concise, operator-friendly
-    # message listing those items and skip the verbose candidate/top-candidate
-    # sections. This keeps the operator-facing output short when agents are
-    # actively working.
-    in_progress_items = _format_in_progress_items(in_progress_output)
-    if in_progress_items:
-        lines: List[str] = ["Agents are currently busy with:"]
-        for item in in_progress_items:
-            # match the visual style requested (em dash bullets)
-            lines.append(f"── {item}")
-        return "\n".join(lines)
-
-    # no in-progress items -> produce full report
-    sections: List[str] = []
-    sections.append("AMPA Delegation")
-    sections.append("In-progress items:")
-    sections.append("- (none)")
-
-    sections.append("Candidates:")
-    if candidates:
-        for cand in candidates:
-            sections.append(f"- {_format_candidate_line(cand)}")
-    else:
-        sections.append("- (none)")
-
-    sections.append("Top candidate:")
-    if top_candidate:
-        sections.append(f"- {_format_candidate_line(top_candidate)}")
-        sections.append("Rationale: selected by wl next (highest priority ready item).")
-    else:
-        sections.append("- (none)")
-        sections.append("Rationale: no candidates returned by wl next.")
-
-    if not candidates and not top_candidate:
-        sections.append(
-            "Summary: delegation is idle (no in-progress items or candidates)."
-        )
-
-    return "\n".join(sections)
-
-
-def _build_dry_run_discord_message(report: str) -> str:
-    summary = _summarize_for_discord(report, max_chars=1000)
-    if summary and summary.strip():
-        return summary
-    LOG.warning("Dry-run discord summary was empty; falling back to raw report content")
-    if report and report.strip():
-        return report.strip()
-    return "(no report details)"
-
-
-def _build_delegation_report(
-    *,
-    in_progress_output: str,
-    candidates: List[Dict[str, Any]],
-    top_candidate: Optional[Dict[str, Any]],
-) -> str:
-    return _build_dry_run_report(
-        in_progress_output=in_progress_output,
-        candidates=candidates,
-        top_candidate=top_candidate,
-    )
-
-
-def _build_delegation_discord_message(report: str) -> str:
-    return _build_dry_run_discord_message(report)
+# ---------------------------------------------------------------------------
+# Delegation helpers — canonical implementations live in ampa.delegation.
+# Re-exported here for backward compatibility with existing callers/tests.
+# ---------------------------------------------------------------------------
+from .delegation import (  # noqa: E402, F401
+    _summarize_for_discord,
+    _trim_text,
+    _content_hash,
+    _format_in_progress_items,
+    _format_candidate_line,
+    _build_dry_run_report,
+    _build_dry_run_discord_message,
+    _build_delegation_report,
+    _build_delegation_discord_message,
+    DelegationOrchestrator,
+)
 
 
 def default_executor(spec: CommandSpec, command_cwd: Optional[str] = None) -> RunResult:
@@ -715,6 +573,18 @@ class Scheduler:
         self.engine: Optional[Engine] = engine
         if self.engine is None:
             self.engine = self._build_engine()
+
+        # Delegation orchestrator — all delegation-specific orchestration is
+        # handled by DelegationOrchestrator (ampa.delegation).
+        self._delegation_orchestrator = DelegationOrchestrator(
+            store=self.store,
+            run_shell=self.run_shell,
+            command_cwd=self.command_cwd,
+            engine=self.engine,
+            candidate_selector=self._candidate_selector,
+            webhook_module=webhook_module,
+            selection_module=selection,
+        )
 
         LOG.info("Command runner timeout configured: %ss", _default_timeout)
         LOG.info(
@@ -942,253 +812,33 @@ class Scheduler:
             LOG.exception("Failed to auto-register watchdog command")
 
     # ------------------------------------------------------------------
-    # Stale delegation watchdog
+    # Delegation — delegated to DelegationOrchestrator
     # ------------------------------------------------------------------
 
-    def _recover_stale_delegations(self) -> List[Dict[str, Any]]:
-        """Detect work items stuck in ``delegated`` stage and reset them.
+    def _sync_orchestrator(self) -> None:
+        """Keep the delegation orchestrator in sync with mutable scheduler state.
 
-        When an ``opencode run`` agent process crashes or hangs without
-        updating the work item, the item remains in
-        ``(in_progress, delegated)`` forever, blocking all future
-        delegations via the ``no_in_progress_items`` invariant.
-
-        This method:
-
-        1. Queries ``wl in_progress --json`` for items with
-           ``stage == "delegated"``.
-        2. Checks each item's ``updatedAt`` against
-           ``AMPA_STALE_DELEGATION_THRESHOLD_SECONDS`` (default 7200s).
-        3. Resets stale items to ``(open, plan_complete)`` so delegation
-           can be retried on the next cycle.
-        4. Posts a ``wl comment`` documenting the recovery.
-        5. Sends a Discord notification.
-
-        Returns a list of dicts describing recovered items (empty list
-        when nothing was stale).
+        Callers (including tests) may reassign ``self.run_shell``,
+        ``self.engine``, or patch ``webhook_module`` / ``selection``
+        after construction.  This method propagates those references to
+        the orchestrator so delegation code paths see the current values.
         """
-        try:
-            thresh_raw = os.getenv("AMPA_STALE_DELEGATION_THRESHOLD_SECONDS", "7200")
-            try:
-                threshold = int(thresh_raw)
-            except Exception:
-                threshold = 7200
-        except Exception:
-            threshold = 7200
+        orch = self._delegation_orchestrator
+        orch.run_shell = self.run_shell
+        orch.engine = self.engine
+        orch._webhook_module = webhook_module
+        orch._selection_module = selection
 
-        now = _utc_now()
-        recovered: List[Dict[str, Any]] = []
-
-        # 1. Query in-progress items
-        try:
-            proc = self.run_shell(
-                "wl in_progress --json",
-                shell=True,
-                check=False,
-                capture_output=True,
-                text=True,
-                cwd=self.command_cwd,
-            )
-        except Exception:
-            LOG.exception("Stale delegation watchdog: wl in_progress failed")
-            return recovered
-
-        if proc.returncode != 0:
-            LOG.warning(
-                "Stale delegation watchdog: wl in_progress returned rc=%s",
-                proc.returncode,
-            )
-            return recovered
-
-        # Parse items
-        try:
-            raw = json.loads(proc.stdout or "null")
-        except Exception:
-            LOG.exception("Stale delegation watchdog: failed to parse wl in_progress")
-            return recovered
-
-        items: List[Dict[str, Any]] = []
-        if isinstance(raw, list):
-            items = [it for it in raw if isinstance(it, dict)]
-        elif isinstance(raw, dict):
-            for key in ("workItems", "work_items", "items", "data"):
-                val = raw.get(key)
-                if isinstance(val, list):
-                    items = [it for it in val if isinstance(it, dict)]
-                    break
-
-        # 2. Filter to delegated items that are stale
-        for item in items:
-            try:
-                stage = item.get("stage") or item.get("currentStage") or ""
-                if stage != "delegated":
-                    continue
-
-                work_id = (
-                    item.get("id") or item.get("work_item_id") or item.get("work_item")
-                )
-                if not work_id:
-                    continue
-
-                # Determine age from updatedAt
-                updated_str = None
-                for k in (
-                    "updated_at",
-                    "updatedAt",
-                    "last_updated_at",
-                    "updated_ts",
-                    "updated",
-                ):
-                    v = item.get(k)
-                    if v:
-                        updated_str = v
-                        break
-
-                updated_dt = _from_iso(updated_str) if updated_str else None
-                age_s = (
-                    int((now - updated_dt).total_seconds())
-                    if updated_dt is not None
-                    else None
-                )
-
-                if age_s is None or age_s <= threshold:
-                    LOG.debug(
-                        "Stale delegation watchdog: %s age=%s <= threshold=%s, skipping",
-                        work_id,
-                        age_s,
-                        threshold,
-                    )
-                    continue
-
-                # 3. Reset the work item to (open, plan_complete)
-                LOG.warning(
-                    "Stale delegation watchdog: recovering %s (age=%ss, threshold=%ss)",
-                    work_id,
-                    age_s,
-                    threshold,
-                )
-                title = item.get("title", "(unknown)")
-                reset_proc = self.run_shell(
-                    f"wl update {work_id} --status open --stage plan_complete --json",
-                    shell=True,
-                    check=False,
-                    capture_output=True,
-                    text=True,
-                    cwd=self.command_cwd,
-                )
-                if reset_proc.returncode != 0:
-                    LOG.error(
-                        "Stale delegation watchdog: failed to reset %s rc=%s stderr=%r",
-                        work_id,
-                        reset_proc.returncode,
-                        (reset_proc.stderr or "")[:512],
-                    )
-                    continue
-
-                # 4. Post a wl comment documenting the recovery
-                comment_text = (
-                    f"[watchdog] Stale delegation recovery: this item was stuck in "
-                    f"(in_progress, delegated) for {age_s}s "
-                    f"(threshold: {threshold}s). "
-                    f"Reset to (open, plan_complete) for re-delegation. "
-                    f"The previous agent session likely crashed or hung "
-                    f"without updating the work item."
-                )
-                try:
-                    self.run_shell(
-                        f'wl comment add {work_id} --comment "{comment_text}" '
-                        f"--author ampa-watchdog --json",
-                        shell=True,
-                        check=False,
-                        capture_output=True,
-                        text=True,
-                        cwd=self.command_cwd,
-                    )
-                except Exception:
-                    LOG.exception(
-                        "Stale delegation watchdog: failed to post comment on %s",
-                        work_id,
-                    )
-
-                recovery_info = {
-                    "work_item_id": str(work_id),
-                    "title": title,
-                    "age_seconds": age_s,
-                    "threshold_seconds": threshold,
-                    "reset_to": "open/plan_complete",
-                }
-                recovered.append(recovery_info)
-                LOG.info(
-                    "Stale delegation watchdog: recovered %s (%s)",
-                    work_id,
-                    title,
-                )
-
-            except Exception:
-                LOG.exception(
-                    "Stale delegation watchdog: error processing item %s",
-                    item.get("id", "?"),
-                )
-
-        # 5. Discord notification (batched)
-        if recovered:
-            try:
-                webhook = os.getenv("AMPA_DISCORD_WEBHOOK")
-                if webhook and webhook_module is not None:
-                    lines = [
-                        f"Stale delegation watchdog recovered {len(recovered)} item(s):"
-                    ]
-                    for info in recovered:
-                        lines.append(
-                            f"- {info['work_item_id']}: {info['title']} "
-                            f"(stale {info['age_seconds']}s, reset to {info['reset_to']})"
-                        )
-                    msg = "\n".join(lines)
-                    payload = webhook_module.build_command_payload(
-                        os.uname().nodename,
-                        now.isoformat(),
-                        "stale_delegation_watchdog",
-                        msg,
-                        0,
-                        title="Stale Delegation Recovery",
-                    )
-                    webhook_module.send_webhook(
-                        webhook, payload, message_type="warning"
-                    )
-            except Exception:
-                LOG.exception(
-                    "Stale delegation watchdog: failed to send Discord notification"
-                )
-
-        return recovered
+    def _recover_stale_delegations(self) -> List[Dict[str, Any]]:
+        """Thin wrapper — delegates to ``DelegationOrchestrator``."""
+        self._sync_orchestrator()
+        return self._delegation_orchestrator.recover_stale_delegations()
 
     def _is_delegation_report_changed(self, command_id: str, report_text: str) -> bool:
-        """Check whether the delegation report content has changed.
-
-        Compares a SHA-256 hash of *report_text* against the hash stored in the
-        scheduler state under ``last_delegation_report_hash``.  Returns True if
-        the content differs (or no previous hash exists) and updates the stored
-        hash.  Returns False when the content is identical to suppress duplicate
-        Discord messages.
-        """
-        new_hash = _content_hash(report_text)
-        state = self.store.get_state(command_id)
-        old_hash = state.get("last_delegation_report_hash")
-        if old_hash == new_hash:
-            LOG.info(
-                "Delegation report unchanged (hash=%s); suppressing Discord webhook",
-                new_hash[:12],
-            )
-            return False
-        # Content changed – persist the new hash
-        state["last_delegation_report_hash"] = new_hash
-        self.store.update_state(command_id, state)
-        LOG.info(
-            "Delegation report changed (old=%s new=%s); sending Discord webhook",
-            (old_hash or "(none)")[:12],
-            new_hash[:12],
+        """Thin wrapper — delegates to ``DelegationOrchestrator``."""
+        return self._delegation_orchestrator._is_delegation_report_changed(
+            command_id, report_text
         )
-        return True
 
     def _global_rate_limited(self, now: dt.datetime) -> bool:
         last_start = self.store.last_global_start()
@@ -1274,59 +924,18 @@ class Scheduler:
         self.store.update_state(spec.command_id, state)
 
     def _inspect_idle_delegation(self) -> Dict[str, Any]:
-        """Lightweight pre-flight check for delegation state.
-
-        Uses the engine's ``CandidateSelector`` to determine whether agents
-        are idle and whether there is a candidate to delegate.  Returns a
-        status dict consumed by ``start_command()`` to decide what to print
-        and whether to proceed with full engine delegation.
-
-        Possible status values:
-        - ``"in_progress"`` — work is already in progress (items in dict)
-        - ``"idle_no_candidate"`` — idle but no actionable candidates
-        - ``"idle_with_candidate"`` — idle with a selected candidate (raw dict)
-        - ``"error"`` — the pre-flight check itself failed
-        """
-        selector = self._candidate_selector
-        if selector is None:
-            LOG.warning("No candidate selector available for inspect")
-            return {"status": "error", "reason": "no_candidate_selector"}
-
-        try:
-            result = selector.select()
-        except Exception:
-            LOG.exception("CandidateSelector.select() raised during inspect")
-            return {"status": "error", "reason": "selector_exception"}
-
-        # Global rejections indicate in-progress items or fetch failures
-        if result.global_rejections:
-            for reason in result.global_rejections:
-                if "in-progress" in reason.lower() or "in_progress" in reason.lower():
-                    # Convert candidates back to raw dicts for the items list
-                    items = (
-                        [c.raw for c in result.candidates] if result.candidates else []
-                    )
-                    return {"status": "in_progress", "items": items}
-            # Other global rejection (e.g. fetch failure)
-            return {
-                "status": "error",
-                "reason": "; ".join(result.global_rejections),
-            }
-
-        if result.selected is None:
-            return {"status": "idle_no_candidate", "payload": None}
-
-        return {
-            "status": "idle_with_candidate",
-            "candidate": result.selected.raw,
-            "candidate_id": result.selected.id,
-            "candidate_title": result.selected.title,
-        }
+        """Thin wrapper — delegates to ``DelegationOrchestrator``."""
+        self._sync_orchestrator()
+        return self._delegation_orchestrator._inspect_idle_delegation()
 
     def start_command(
         self, spec: CommandSpec, now: Optional[dt.datetime] = None
     ) -> RunResult:
         now = now or _utc_now()
+        # Sync mutable scheduler state to the delegation orchestrator so that
+        # callers (including tests) that reassign ``sched.run_shell`` after
+        # construction see the updated reference in delegation code paths.
+        self._sync_orchestrator()
         state = self.store.get_state(spec.command_id)
         state.update({"running": True, "last_start_ts": _to_iso(now)})
         self.store.update_state(spec.command_id, state)
@@ -1376,258 +985,8 @@ class Scheduler:
             output = run.output
             exit_code = run.exit_code
         if spec.command_type == "delegation":
-            LOG.info(
-                "Handling delegation command: %s (audit_only=%s)",
-                spec.command_id,
-                _bool_meta(spec.metadata.get("audit_only")),
-            )
-            # Inspect current state first. If there is a candidate that will be
-            # dispatched we want to avoid sending the pre-dispatch report to
-            # Discord (otherwise operators see two nearly-identical messages).
-            audit_only = _bool_meta(spec.metadata.get("audit_only"))
-            inspect = self._inspect_idle_delegation()
-            status = inspect.get("status")
-
-            # Only generate and send a pre-dispatch report when we are not
-            # about to dispatch a candidate. If we will dispatch (status
-            # == 'idle_with_candidate' and audit_only is false) skip the
-            # pre-report; a post-dispatch report will be sent after the
-            # delegation completes.
-            report = None
-            sent_pre_report = False
-            if audit_only or status != "idle_with_candidate":
-                try:
-                    LOG.info(
-                        "Generating pre-dispatch delegation report for %s",
-                        spec.command_id,
-                    )
-                    report = self._run_delegation_report(spec)
-                except Exception:
-                    LOG.exception("Delegation report generation failed")
-                if report:
-                    LOG.info(
-                        "Pre-dispatch delegation report generated (len=%d)", len(report)
-                    )
-                    output = report
-                    # A pre-report was generated so the idle-no-candidate
-                    # fallback webhook should not fire regardless of whether
-                    # the dedup check suppresses this particular send.
-                    sent_pre_report = True
-                    try:
-                        webhook = os.getenv("AMPA_DISCORD_WEBHOOK")
-                        if webhook and self._is_delegation_report_changed(
-                            spec.command_id, report
-                        ):
-                            message = _build_delegation_discord_message(report)
-                            payload = webhook_module.build_command_payload(
-                                os.uname().nodename,
-                                run.end_ts.isoformat(),
-                                spec.command_id,
-                                message,
-                                run.exit_code,
-                                title=(
-                                    spec.title
-                                    or spec.metadata.get("discord_label")
-                                    or "Delegation Report"
-                                ),
-                            )
-                            webhook_module.send_webhook(
-                                webhook, payload, message_type="command"
-                            )
-                            LOG.info(
-                                "Sent pre-dispatch webhook for %s", spec.command_id
-                            )
-                    except Exception:
-                        LOG.exception("Delegation discord notification failed")
-            # if we skipped creating a pre-report, 'report' stays None and
-            # 'output' remains as previously (possibly None). Proceed to
-            # handling the inspected status below.
-
-            # ensure status variable is available below
-            # status may already be set above; if not, extract it
-            status = inspect.get("status")
-            if status == "in_progress":
-                print(
-                    "There is work in progress and thus no new work will be delegated."
-                )
-                LOG.info("Delegation skipped because work is in-progress")
-                result = {
-                    "note": "Delegation: skipped (in_progress items)",
-                    "dispatched": False,
-                    "rejected": [],
-                    "idle_webhook_sent": False,
-                }
-            elif status == "idle_no_candidate":
-                # More descriptive idle message for operators
-                idle_msg = "Agents are idle: no actionable items found"
-                print(idle_msg)
-                LOG.info("Delegation: idle_no_candidate - %s", idle_msg)
-                result = {
-                    "note": "Delegation: skipped (no actionable candidates)",
-                    "dispatched": False,
-                    "rejected": [],
-                    "idle_webhook_sent": False,
-                }
-                # If we did not already send a detailed pre-report, send a
-                # short webhook message so Discord reflects the idle state.
-                if not sent_pre_report:
-                    try:
-                        webhook = os.getenv("AMPA_DISCORD_WEBHOOK")
-                        if webhook and self._is_delegation_report_changed(
-                            spec.command_id, idle_msg
-                        ):
-                            payload = webhook_module.build_command_payload(
-                                os.uname().nodename,
-                                run.end_ts.isoformat(),
-                                spec.command_id,
-                                idle_msg,
-                                0,
-                                title=(
-                                    spec.title
-                                    or spec.metadata.get("discord_label")
-                                    or "Delegation Report"
-                                ),
-                            )
-                            webhook_module.send_webhook(
-                                webhook, payload, message_type="command"
-                            )
-                    except Exception:
-                        LOG.exception("Failed to send idle-state webhook")
-            elif status == "idle_with_candidate":
-                delegate_id = inspect.get("candidate_id")
-                delegate_title = inspect.get("candidate_title") or "(no title)"
-                print(f"Starting work on: {delegate_title} - {delegate_id or '?'}")
-                result = self._run_idle_delegation(audit_only=audit_only, spec=spec)
-                # If delegation did not dispatch anything, ensure operators see
-                # an idle-state message unless a detailed idle webhook was
-                # already sent by the delegation routine.
-                try:
-                    note = (
-                        result.get("note") if isinstance(result, dict) else str(result)
-                    )
-                    dispatched = bool(
-                        result.get("dispatched") if isinstance(result, dict) else False
-                    )
-                    idle_webhook_sent = bool(
-                        result.get("idle_webhook_sent")
-                        if isinstance(result, dict)
-                        else False
-                    )
-                    if not dispatched:
-                        idle_msg = "Agents are idle: no actionable items found"
-                        print(idle_msg)
-                        # If we didn't already send a detailed pre-report or the
-                        # delegation routine didn't post its detailed idle webhook,
-                        # send a short idle notification so Discord reflects the
-                        # current idle state.
-                        if not sent_pre_report and not idle_webhook_sent:
-                            webhook = os.getenv("AMPA_DISCORD_WEBHOOK")
-                            if webhook and self._is_delegation_report_changed(
-                                spec.command_id, idle_msg
-                            ):
-                                try:
-                                    payload = webhook_module.build_command_payload(
-                                        os.uname().nodename,
-                                        run.end_ts.isoformat(),
-                                        spec.command_id,
-                                        idle_msg,
-                                        0,
-                                        title=(
-                                            spec.title
-                                            or spec.metadata.get("discord_label")
-                                            or "Delegation Report"
-                                        ),
-                                    )
-                                    webhook_module.send_webhook(
-                                        webhook, payload, message_type="command"
-                                    )
-                                except Exception:
-                                    LOG.exception("Failed to send idle-state webhook")
-                except Exception:
-                    LOG.exception("Failed to handle no-actionable-candidates path")
-            else:
-                print("There is no candidate to delegate.")
-                result = {
-                    "note": "Delegation: skipped (in_progress check failed)",
-                    "dispatched": False,
-                    "rejected": [],
-                    "idle_webhook_sent": False,
-                }
-            # Send a follow-up Discord notification when a delegation action
-            # was actually dispatched so the Discord report reflects the
-            # resulting state instead of the pre-delegation dry-run.
-            try:
-                webhook = os.getenv("AMPA_DISCORD_WEBHOOK")
-                if webhook:
-                    # If something was dispatched, re-run the report to capture
-                    # the post-dispatch state and post that as an update.
-                    dispatched_flag = False
-                    if isinstance(result, dict):
-                        dispatched_flag = bool(result.get("dispatched"))
-                    if dispatched_flag:
-                        try:
-                            post_report = self._run_delegation_report(spec)
-                            if post_report:
-                                # Update the stored hash so the next cycle
-                                # compares against this post-dispatch state
-                                # rather than the stale pre-dispatch content.
-                                self._is_delegation_report_changed(
-                                    spec.command_id, post_report
-                                )
-                                post_message = _build_delegation_discord_message(
-                                    post_report
-                                )
-                                payload = webhook_module.build_command_payload(
-                                    os.uname().nodename,
-                                    run.end_ts.isoformat(),
-                                    spec.command_id,
-                                    post_message,
-                                    run.exit_code,
-                                    title=(
-                                        spec.title
-                                        or spec.metadata.get("discord_label")
-                                        or "Delegation Report"
-                                    ),
-                                )
-                                webhook_module.send_webhook(
-                                    webhook, payload, message_type="command"
-                                )
-                        except Exception:
-                            LOG.exception("Failed to send post-delegation webhook")
-            except Exception:
-                LOG.exception("Delegation webhook follow-up failed")
-
-            # Use the structured result.note when available
-            summary_note = None
-            if isinstance(result, dict):
-                summary_note = result.get("note")
-            else:
-                try:
-                    summary_note = str(result)
-                except Exception:
-                    summary_note = None
-            LOG.info("Delegation summary: %s", summary_note)
-            # Attach delegation result as metadata on the RunResult so
-            # formatters can include the action taken.
-            delegation_meta: Dict[str, Any] = {}
-            if isinstance(result, dict):
-                delegation_meta["delegation"] = result
-            if isinstance(run, CommandRunResult):
-                run = CommandRunResult(
-                    start_ts=run.start_ts,
-                    end_ts=run.end_ts,
-                    exit_code=run.exit_code,
-                    output=output or run.output,
-                    metadata=delegation_meta or None,
-                )
-            else:
-                run = RunResult(
-                    start_ts=run.start_ts,
-                    end_ts=run.end_ts,
-                    exit_code=run.exit_code,
-                    metadata=delegation_meta or None,
-                )
-            self._record_run(spec, run, exit_code, output)
+            run = self._delegation_orchestrator.execute(spec, run, output)
+            self._record_run(spec, run, run.exit_code, getattr(run, "output", output))
             return run
         self._record_run(spec, run, exit_code, output)
         # After recording run, perform any command-specific post actions
@@ -2794,165 +2153,23 @@ class Scheduler:
     def _run_idle_delegation(
         self, *, audit_only: bool, spec: Optional[CommandSpec] = None
     ) -> Dict[str, Any]:
-        """Attempt to dispatch work when agents are idle.
-
-        Delegates all candidate selection, invariant evaluation, state
-        transitions, and dispatch to the engine.  Converts the EngineResult
-        back into the dict format expected by callers in start_command()
-        and _run_triage_audit().
-
-        Returns a dict with at least the following keys:
-        - note: human-readable summary
-        - dispatched: bool (True if a delegation was dispatched)
-        - rejected: list of rejected candidate summaries (may be empty)
-        - idle_webhook_sent: bool (True if a detailed idle webhook was posted)
-        - delegate_info: optional dict with dispatch details when dispatched
-        """
-        assert self.engine is not None  # guaranteed by __init__
-
-        if audit_only:
-            return {
-                "note": "Delegation: skipped (audit_only)",
-                "dispatched": False,
-                "rejected": [],
-                "idle_webhook_sent": False,
-            }
-
-        try:
-            result = self.engine.process_delegation()
-        except Exception:
-            LOG.exception("Engine process_delegation raised an exception")
-            return {
-                "note": "Delegation: engine error",
-                "dispatched": False,
-                "rejected": [],
-                "idle_webhook_sent": False,
-                "error": "engine exception",
-            }
-
-        # Convert EngineResult to dict format.
-        status = result.status
-
-        if status == EngineStatus.SUCCESS:
-            action = result.action or "unknown"
-            wid = result.work_item_id or "?"
-            delegate_title = ""
-            if result.candidate_result and result.candidate_result.selected:
-                delegate_title = result.candidate_result.selected.title
-            delegate_info: Dict[str, Any] = {
-                "action": action,
-                "id": wid,
-                "title": delegate_title,
-                "stdout": "",
-                "stderr": "",
-            }
-            if result.dispatch_result:
-                delegate_info["pid"] = result.dispatch_result.pid
-            return {
-                "note": f"Delegation: dispatched {action} {wid}",
-                "dispatched": True,
-                "delegate_info": delegate_info,
-                "rejected": self._engine_rejections(result),
-                "idle_webhook_sent": False,
-            }
-
-        if status == EngineStatus.NO_CANDIDATES:
-            # The engine already sent a Discord notification via its notifier.
-            return {
-                "note": "Delegation: skipped (no wl next candidates)",
-                "dispatched": False,
-                "rejected": self._engine_rejections(result),
-                "idle_webhook_sent": True,
-            }
-
-        if status == EngineStatus.SKIPPED:
-            return {
-                "note": f"Delegation: skipped ({result.reason})",
-                "dispatched": False,
-                "rejected": [],
-                "idle_webhook_sent": False,
-            }
-
-        if status in (
-            EngineStatus.REJECTED,
-            EngineStatus.INVARIANT_FAILED,
-        ):
-            return {
-                "note": f"Delegation: blocked ({result.reason})",
-                "dispatched": False,
-                "rejected": self._engine_rejections(result),
-                "idle_webhook_sent": False,
-            }
-
-        if status == EngineStatus.DISPATCH_FAILED:
-            return {
-                "note": f"Delegation: failed ({result.reason})",
-                "dispatched": False,
-                "rejected": self._engine_rejections(result),
-                "idle_webhook_sent": False,
-                "error": result.reason,
-            }
-
-        # ERROR or any other unexpected status
-        return {
-            "note": f"Delegation: engine error ({result.reason})",
-            "dispatched": False,
-            "rejected": self._engine_rejections(result),
-            "idle_webhook_sent": False,
-            "error": result.reason,
-        }
+        """Thin wrapper — delegates to ``DelegationOrchestrator``."""
+        self._sync_orchestrator()
+        return self._delegation_orchestrator.run_idle_delegation(
+            audit_only=audit_only, spec=spec
+        )
 
     @staticmethod
     def _engine_rejections(result: EngineResult) -> List[Dict[str, str]]:
-        """Extract rejected-candidate summaries from an EngineResult for
-        backward compatibility with the legacy delegation dict format."""
-        rejected: List[Dict[str, str]] = []
-        cr = getattr(result, "candidate_result", None)
-        if cr is None:
-            return rejected
-        for rej in getattr(cr, "rejections", ()):
-            c = getattr(rej, "candidate", None)
-            rejected.append(
-                {
-                    "id": getattr(c, "id", "?") if c else "?",
-                    "title": getattr(c, "title", "(unknown)") if c else "(unknown)",
-                    "reason": getattr(rej, "reason", "rejected"),
-                }
-            )
-        return rejected
+        """Thin wrapper — delegates to ``DelegationOrchestrator``."""
+        return DelegationOrchestrator._engine_rejections(result)
 
     def _run_delegation_report(
         self, spec: Optional[CommandSpec] = None
     ) -> Optional[str]:
-        def _call(cmd: str) -> subprocess.CompletedProcess:
-            LOG.debug("Running shell (delegation): %s", cmd)
-            return self.run_shell(
-                cmd,
-                shell=True,
-                check=False,
-                capture_output=True,
-                text=True,
-                cwd=self.command_cwd,
-            )
-
-        in_progress_text = ""
-        proc = _call("wl in_progress")
-        if proc.stdout:
-            in_progress_text += proc.stdout
-        if proc.stderr and not in_progress_text:
-            in_progress_text += proc.stderr
-
-        candidates, _payload = selection.fetch_candidates(
-            run_shell=self.run_shell, command_cwd=self.command_cwd
-        )
-        top_candidate = candidates[0] if candidates else None
-
-        report = _build_delegation_report(
-            in_progress_output=_trim_text(in_progress_text),
-            candidates=candidates,
-            top_candidate=top_candidate,
-        )
-        return report
+        """Thin wrapper — delegates to ``DelegationOrchestrator``."""
+        self._sync_orchestrator()
+        return self._delegation_orchestrator.run_delegation_report(spec)
 
     def _post_startup_message(self) -> None:
         try:


### PR DESCRIPTION
## Summary

- Extract ~730 lines of delegation orchestration and report generation code from `scheduler.py` into a new `DelegationOrchestrator` class in `ampa/delegation.py`
- Replace duplicated formatting functions in `scheduler_cli.py` and `triage_audit.py` with imports from `ampa.delegation`
- Fix test hang caused by `_sync_orchestrator()` not propagating `webhook_module`/`selection` references to the orchestrator

## What changed

### `ampa/delegation.py` (new module, ~999 lines)
- `DelegationOrchestrator` class with methods: `execute()`, `run_idle_delegation()`, `run_delegation_report()`, `recover_stale_delegations()`, `_inspect_idle_delegation()`, `_is_delegation_report_changed()`, `_engine_rejections()`
- Module-level helpers: `_summarize_for_discord`, `_content_hash`, `_trim_text`, `_format_in_progress_items`, `_format_candidate_line`, `_build_dry_run_report`, `_build_dry_run_discord_message`, `_build_delegation_report`, `_build_delegation_discord_message`

### `ampa/scheduler.py` (-915 lines)
- Replaced all 9 module-level formatting functions with re-exports from `delegation.py`
- Replaced 6 Scheduler methods with thin wrappers that delegate to `DelegationOrchestrator`
- Collapsed ~250-line delegation branch in `start_command()` to 3 lines via `DelegationOrchestrator.execute()`
- Added `_sync_orchestrator()` to propagate `run_shell`, `engine`, `webhook_module`, and `selection` to the orchestrator

### `ampa/scheduler_cli.py` (-96 lines)
- Replaced duplicated `_trim_text`, `_build_delegation_report`, `_build_delegation_discord_message` with imports from `ampa.delegation`

### `ampa/triage_audit.py` (-191 lines)
- Replaced local `_summarize_for_discord`, `_trim_text`, `_run_delegation_from_runner`, `_run_delegation_report_for_preview` with `DelegationOrchestrator` usage

## Testing

All 532 tests pass. No behavioral changes — purely structural refactoring.

## Work Item

SA-0MLXEM41U1VIK3TB