### PR TITLE
Fix dead-letter default path to use project-local .worklog/ampa/

### DIFF
--- a/ampa/notifications.py
+++ b/ampa/notifications.py
@@ -67,10 +67,22 @@ def _state_file_path() -> str:
 # ---------------------------------------------------------------------------
 
 
+def _default_deadletter_path() -> str:
+    """Return the default dead-letter file path.
+
+    Uses ``<cwd>/.worklog/ampa/deadletter.log`` so the file is project-local,
+    discoverable alongside other AMPA state files, and writable by non-root
+    users.  The daemon is always spawned with ``cwd = projectRoot`` (see
+    ampa.mjs) so ``os.getcwd()`` gives the correct project root.
+    """
+    return os.path.join(os.getcwd(), ".worklog", "ampa", "deadletter.log")
+
+
 def dead_letter(payload: Dict[str, Any], reason: Optional[str] = None) -> None:
     """Persist a failed notification so it is not silently lost.
 
-    Writes to ``AMPA_DEADLETTER_FILE`` (default ``/var/log/ampa_deadletter.log``).
+    Writes to ``AMPA_DEADLETTER_FILE`` (default
+    ``<projectRoot>/.worklog/ampa/deadletter.log``).
     """
     try:
         try:
@@ -87,7 +99,7 @@ def dead_letter(payload: Dict[str, Any], reason: Optional[str] = None) -> None:
             "reason": reason,
             "payload": payload,
         }
-        dl_file = os.getenv("AMPA_DEADLETTER_FILE", "/var/log/ampa_deadletter.log")
+        dl_file = os.getenv("AMPA_DEADLETTER_FILE") or _default_deadletter_path()
         try:
             parent = os.path.dirname(dl_file)
             if parent and not os.path.isdir(parent):


### PR DESCRIPTION
## Summary

The dead-letter fallback in `ampa/notifications.py:dead_letter()` defaulted to `/var/log/ampa_deadletter.log`, which is not writable by non-root users. This caused `PermissionError` on startup race conditions, silently losing notifications.

This PR changes the default to `<projectRoot>/.worklog/ampa/deadletter.log`, consistent with how other AMPA state files are stored (scheduler store, daemon .env, etc.).

## Changes

- **`ampa/notifications.py`**: Added `_default_deadletter_path()` helper that returns `os.path.join(os.getcwd(), ".worklog", "ampa", "deadletter.log")`, following the same `os.getcwd()` convention used by `daemon.py:_project_ampa_dir()` and `scheduler.py`. Updated `dead_letter()` to use `os.getenv("AMPA_DEADLETTER_FILE") or _default_deadletter_path()`.
- **`tests/test_notifications.py`**: Added 3 new tests:
  - `test_default_path_is_project_local` — verifies the default path ends with `.worklog/ampa/deadletter.log`
  - `test_writes_to_default_path_without_env_var` — verifies dead-letter writes succeed with no env var configuration
  - `test_env_var_override_still_works` — verifies `AMPA_DEADLETTER_FILE` env var override still takes precedence

## How to Test

1. Unset `AMPA_DEADLETTER_FILE` and start AMPA
2. Send a notification before the bot socket is ready
3. Verify dead-letter is written to `.worklog/ampa/deadletter.log` without errors

Or run the tests: `python -m pytest tests/test_notifications.py::TestDeadLetter -v`

## Review Focus

- The change from `os.getenv("AMPA_DEADLETTER_FILE", "/var/log/...")` to `os.getenv("AMPA_DEADLETTER_FILE") or _default_deadletter_path()` means an empty string env var now also falls through to the default path (slightly better behavior)
- The `_default_deadletter_path()` helper uses `os.getcwd()` consistent with `daemon.py` and `scheduler.py`

## Work Item

SA-0MLZKUVMD0QADOHM