### PR TITLE
SA-0MKZT5NIF19BLRLH: Exclude procedural next steps from intake work item descriptions

### DIFF
--- a/command/intake.md
+++ b/command/intake.md
@@ -40,11 +40,7 @@ The command implements the procedural workflow below. Each numbered step is part
 - Prefer short multiple-choice suggestions where possible, but always allow freeform responses.
 - The goal is not to capture an exhaustive spec, but to gather sufficient detail to create a clear Worklog work item that will be used to either seed a PRD, update an existing one, or if the work is small and well-defined, be implemented directly from the Worklog work item.
 
-- Whenever you are recommending next steps you MUST make the first one a progression to the next step in the process defined below, with a summary of what that step involves.
-
-## Note
-
-- This Hard requirements section is populated with the mandatory progression rule above; review the rest of the hard requirements for task-specific constraints.
+- Do not include procedural next steps (e.g., "Proceed to planning", "Break into sub-tasks") in the intake brief or work item description. Workflow progression is handled by the workflow system via stage transitions and delegation dispatch, not by the work item content.
 
 ## Process (must follow)
 
@@ -104,11 +100,11 @@ After each stage output: "Finished <review-type> review: <brief notes of changes
 
 - The five Intake review types are:
   1. Completeness
-     - Ensure Problem, Success criteria, Constraints, and Suggested next step are present and actionable. Add missing bullets or concise placeholders when obvious.
+     - Ensure Problem, Success criteria, and Constraints are present and actionable. Add missing bullets or concise placeholders when obvious.
   2. Capture fidelity
      - Verify the user's answers are accurately and neutrally represented. Shorten or rephrase only for clarity; do not change meaning.
   3. Related-work & traceability
-  - Confirm related docs/work items are correctly referenced and that the recommended next step references the correct path/work item ids.
+   - Confirm related docs/work items are correctly referenced.
   4. Risks & assumptions
      - Add missing risks and mitigations, failure modes, and assumptions in short bullets.
      - Ensure that a risk addressing scope screep is present. The mitigaation is to record opportunities for additional features/refactorings as work items linked to the main item, rather than expanding the scope of the current item.


### PR DESCRIPTION
## Summary

Remove the "Suggested next step" requirement from the `/intake` command so that procedural workflow guidance is no longer written into work item descriptions. Workflow progression is already handled by the workflow system (stage transitions and delegation dispatch), making these sections redundant noise in work item descriptions.

**Work item:** SA-0MKZT5NIF19BLRLH

## Changes

Single file modified: `command/intake.md` (3 insertions, 7 deletions)

1. **Replaced** the hard requirement mandating next-step recommendations (old line 43) with an explicit prohibition against procedural next steps in intake briefs and work item descriptions.
2. **Removed** the "Note" section (old lines 45-47) that only existed to reference the now-removed progression rule.
3. **Removed** "Suggested next step" from the completeness review checklist (review stage 1).
4. **Removed** "recommended next step references the correct path/work item ids" from the related-work & traceability review (review stage 3).

## What to focus on in review

- Verify the replacement prohibition text on line 43 is clear and unambiguous.
- Confirm the five mini-review stages still read coherently after the removals.
- Check that no other references to "next step" were missed in the file.

## Testing

This is a documentation/instruction file change. No automated tests apply. Verify by:
- Reading `command/intake.md` to confirm the "Suggested next step" pattern is fully removed.
- Running `/intake` on a test work item and confirming no "Suggested next step" section appears in the output.