### PR TITLE
SA-0MM36ESPX09ZLRG1: Extract scheduler types to dedicated module

### DIFF
--- a/ampa/delegation.py
+++ b/ampa/delegation.py
@@ -24,6 +24,13 @@ from typing import Any, Callable, Dict, List, Optional
 
 from .engine.candidates import CandidateSelector
 from .engine.core import Engine, EngineResult, EngineStatus
+from .scheduler_types import (
+    _utc_now,
+    _from_iso,
+    _bool_meta,
+    CommandRunResult,
+    RunResult,
+)
 
 LOG = logging.getLogger("ampa.delegation")
 
@@ -31,22 +38,6 @@ LOG = logging.getLogger("ampa.delegation")
 # ---------------------------------------------------------------------------
 # Utility / formatting helpers
 # ---------------------------------------------------------------------------
-
-
-def _utc_now() -> dt.datetime:
-    return dt.datetime.now(dt.timezone.utc)
-
-
-def _from_iso(value: Optional[str]) -> Optional[dt.datetime]:
-    if not value:
-        return None
-    try:
-        v = value
-        if isinstance(v, str) and v.endswith("Z"):
-            v = v[:-1] + "+00:00"
-        return dt.datetime.fromisoformat(v)
-    except Exception:
-        return None
 
 
 def _trim_text(value: Optional[str]) -> str:
@@ -760,10 +751,6 @@ class DelegationOrchestrator:
         RunResult
             An updated RunResult with delegation metadata attached.
         """
-        # Avoid importing at module level to prevent circular imports.
-        # These are only needed when execute() is called.
-        from .scheduler import _bool_meta, CommandRunResult, RunResult
-
         notif = self._notifications_module
 
         # Determine effective audit-only behaviour.  If an operator has set

--- a/ampa/scheduler.py
+++ b/ampa/scheduler.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import dataclasses
 import datetime as dt
 import hashlib
 import json
@@ -67,148 +66,23 @@ from .engine.adapters import (
     DiscordNotificationSender,
 )
 
+# ---------------------------------------------------------------------------
+# Shared data classes and utilities — canonical definitions live in
+# ampa.scheduler_types.  Re-exported here for backward compatibility.
+# ---------------------------------------------------------------------------
+from .scheduler_types import (  # noqa: F401
+    CommandSpec,
+    SchedulerConfig,
+    RunResult,
+    CommandRunResult,
+    _utc_now,
+    _to_iso,
+    _from_iso,
+    _seconds_between,
+    _bool_meta,
+)
+
 LOG = logging.getLogger("ampa.scheduler")
-
-
-def _utc_now() -> dt.datetime:
-    return dt.datetime.now(dt.timezone.utc)
-
-
-def _to_iso(value: Optional[dt.datetime]) -> Optional[str]:
-    if value is None:
-        return None
-    return value.isoformat()
-
-
-def _from_iso(value: Optional[str]) -> Optional[dt.datetime]:
-    if not value:
-        return None
-    try:
-        # Accept common ISO forms including trailing 'Z' (UTC) by normalizing
-        # to an offset-aware representation that datetime.fromisoformat can parse.
-        v = value
-        if isinstance(v, str) and v.endswith("Z"):
-            v = v[:-1] + "+00:00"
-        return dt.datetime.fromisoformat(v)
-    except Exception:
-        return None
-
-
-def _seconds_between(now: dt.datetime, then: Optional[dt.datetime]) -> Optional[float]:
-    if then is None:
-        return None
-    return (now - then).total_seconds()
-
-
-@dataclasses.dataclass(frozen=True)
-class CommandSpec:
-    # Keep positional ordering compatible with existing tests and callers.
-    command_id: str
-    command: str
-    requires_llm: bool
-    frequency_minutes: int
-    priority: int
-    metadata: Dict[str, Any]
-    title: Optional[str] = None
-    max_runtime_minutes: Optional[int] = None
-    command_type: str = "shell"
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {
-            "id": self.command_id,
-            "command": self.command,
-            "title": self.title,
-            "requires_llm": self.requires_llm,
-            "frequency_minutes": self.frequency_minutes,
-            "priority": self.priority,
-            "metadata": self.metadata,
-            "max_runtime_minutes": self.max_runtime_minutes,
-            "type": self.command_type,
-        }
-
-    @staticmethod
-    def from_dict(data: Dict[str, Any]) -> "CommandSpec":
-        return CommandSpec(
-            command_id=str(data["id"]),
-            command=str(data.get("command", "")),
-            requires_llm=bool(data.get("requires_llm", False)),
-            frequency_minutes=int(data.get("frequency_minutes", 1)),
-            priority=int(data.get("priority", 0)),
-            metadata=dict(data.get("metadata", {})),
-            title=data.get("title"),
-            max_runtime_minutes=data.get("max_runtime_minutes"),
-            command_type=str(data.get("type", "shell")),
-        )
-
-
-@dataclasses.dataclass(frozen=True)
-class SchedulerConfig:
-    poll_interval_seconds: int
-    global_min_interval_seconds: int
-    priority_weight: float
-    store_path: str
-    llm_healthcheck_url: str
-    max_run_history: int
-
-    @staticmethod
-    def from_env() -> "SchedulerConfig":
-        def _int(name: str, default: int) -> int:
-            raw = os.getenv(name, str(default))
-            try:
-                value = int(raw)
-                if value <= 0:
-                    raise ValueError("must be positive")
-                return value
-            except Exception:
-                LOG.warning("Invalid %s=%r; using %s", name, raw, default)
-                return default
-
-        def _float(name: str, default: float) -> float:
-            raw = os.getenv(name, str(default))
-            try:
-                value = float(raw)
-                if value < 0:
-                    raise ValueError("must be non-negative")
-                return value
-            except Exception:
-                LOG.warning("Invalid %s=%r; using %s", name, raw, default)
-                return default
-
-        # The scheduler store MUST exist at the local per-project path.
-        # The daemon is spawned with cwd=projectRoot (ampa.mjs) so
-        # os.getcwd() gives the correct project root at startup.
-        store_path = os.path.join(
-            os.getcwd(), ".worklog", "ampa", "scheduler_store.json"
-        )
-        return SchedulerConfig(
-            poll_interval_seconds=_int("AMPA_SCHEDULER_POLL_INTERVAL_SECONDS", 5),
-            global_min_interval_seconds=_int(
-                "AMPA_SCHEDULER_GLOBAL_MIN_INTERVAL_SECONDS", 60
-            ),
-            priority_weight=_float("AMPA_SCHEDULER_PRIORITY_WEIGHT", 0.1),
-            store_path=store_path,
-            llm_healthcheck_url=os.getenv(
-                "AMPA_LLM_HEALTHCHECK_URL", "http://localhost:8000/health"
-            ),
-            max_run_history=_int("AMPA_SCHEDULER_MAX_RUN_HISTORY", 50),
-        )
-
-
-@dataclasses.dataclass(frozen=True)
-class RunResult:
-    start_ts: dt.datetime
-    end_ts: dt.datetime
-    exit_code: int
-    metadata: Optional[Dict[str, Any]] = dataclasses.field(default=None)
-
-    @property
-    def duration_seconds(self) -> float:
-        return (self.end_ts - self.start_ts).total_seconds()
-
-
-@dataclasses.dataclass(frozen=True)
-class CommandRunResult(RunResult):
-    output: str = ""
 
 
 class SchedulerStore:
@@ -331,14 +205,6 @@ def default_llm_probe(url: str) -> bool:
         return resp.status_code < 500
     except Exception:
         return False
-
-
-def _bool_meta(value: Any) -> bool:
-    if isinstance(value, bool):
-        return value
-    if value is None:
-        return False
-    return str(value).strip().lower() in ("1", "true", "yes", "y", "on")
 
 
 # ---------------------------------------------------------------------------

--- a/ampa/scheduler_cli.py
+++ b/ampa/scheduler_cli.py
@@ -19,16 +19,18 @@ import re
 from typing import Any, Dict, List, Optional
 
 from . import daemon, notifications as notifications_module, selection
-from .scheduler import (
+from .scheduler_types import (
     CommandSpec,
-    SchedulerStore,
     SchedulerConfig,
-    load_scheduler,
     RunResult,
     CommandRunResult,
     _utc_now,
     _from_iso,
     _to_iso,
+)
+from .scheduler import (
+    SchedulerStore,
+    load_scheduler,
     build_error_report,
     render_error_report,
     render_error_report_json,

--- a/ampa/scheduler_types.py
+++ b/ampa/scheduler_types.py
@@ -1,0 +1,191 @@
+"""Shared data classes and utility functions for the AMPA scheduler.
+
+This module contains the pure data types (``CommandSpec``, ``SchedulerConfig``,
+``RunResult``, ``CommandRunResult``) and stateless utility functions
+(``_utc_now``, ``_to_iso``, ``_from_iso``, ``_seconds_between``, ``_bool_meta``)
+that are used across the scheduler, delegation, triage-audit, CLI, and store
+modules.
+
+Extracting these into their own module breaks the dependency on
+``ampa.scheduler`` for modules that only need data classes or time helpers,
+eliminating circular-import risks.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime as dt
+import logging
+import os
+from typing import Any, Dict, Optional
+
+LOG = logging.getLogger("ampa.scheduler")
+
+
+# ---------------------------------------------------------------------------
+# Time / conversion utilities
+# ---------------------------------------------------------------------------
+
+
+def _utc_now() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def _to_iso(value: Optional[dt.datetime]) -> Optional[str]:
+    if value is None:
+        return None
+    return value.isoformat()
+
+
+def _from_iso(value: Optional[str]) -> Optional[dt.datetime]:
+    if not value:
+        return None
+    try:
+        # Accept common ISO forms including trailing 'Z' (UTC) by normalizing
+        # to an offset-aware representation that datetime.fromisoformat can parse.
+        v = value
+        if isinstance(v, str) and v.endswith("Z"):
+            v = v[:-1] + "+00:00"
+        return dt.datetime.fromisoformat(v)
+    except Exception:
+        return None
+
+
+def _seconds_between(now: dt.datetime, then: Optional[dt.datetime]) -> Optional[float]:
+    if then is None:
+        return None
+    return (now - then).total_seconds()
+
+
+# ---------------------------------------------------------------------------
+# Metadata helpers
+# ---------------------------------------------------------------------------
+
+
+def _bool_meta(value: Any) -> bool:
+    """Coerce a metadata value to bool.
+
+    Accepts ``bool``, ``None``, and common truthy string representations
+    (``"1"``, ``"true"``, ``"yes"``, ``"y"``, ``"on"``).
+    """
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in ("1", "true", "yes", "y", "on")
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class CommandSpec:
+    # Keep positional ordering compatible with existing tests and callers.
+    command_id: str
+    command: str
+    requires_llm: bool
+    frequency_minutes: int
+    priority: int
+    metadata: Dict[str, Any]
+    title: Optional[str] = None
+    max_runtime_minutes: Optional[int] = None
+    command_type: str = "shell"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.command_id,
+            "command": self.command,
+            "title": self.title,
+            "requires_llm": self.requires_llm,
+            "frequency_minutes": self.frequency_minutes,
+            "priority": self.priority,
+            "metadata": self.metadata,
+            "max_runtime_minutes": self.max_runtime_minutes,
+            "type": self.command_type,
+        }
+
+    @staticmethod
+    def from_dict(data: Dict[str, Any]) -> "CommandSpec":
+        return CommandSpec(
+            command_id=str(data["id"]),
+            command=str(data.get("command", "")),
+            requires_llm=bool(data.get("requires_llm", False)),
+            frequency_minutes=int(data.get("frequency_minutes", 1)),
+            priority=int(data.get("priority", 0)),
+            metadata=dict(data.get("metadata", {})),
+            title=data.get("title"),
+            max_runtime_minutes=data.get("max_runtime_minutes"),
+            command_type=str(data.get("type", "shell")),
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class SchedulerConfig:
+    poll_interval_seconds: int
+    global_min_interval_seconds: int
+    priority_weight: float
+    store_path: str
+    llm_healthcheck_url: str
+    max_run_history: int
+
+    @staticmethod
+    def from_env() -> "SchedulerConfig":
+        def _int(name: str, default: int) -> int:
+            raw = os.getenv(name, str(default))
+            try:
+                value = int(raw)
+                if value <= 0:
+                    raise ValueError("must be positive")
+                return value
+            except Exception:
+                LOG.warning("Invalid %s=%r; using %s", name, raw, default)
+                return default
+
+        def _float(name: str, default: float) -> float:
+            raw = os.getenv(name, str(default))
+            try:
+                value = float(raw)
+                if value < 0:
+                    raise ValueError("must be non-negative")
+                return value
+            except Exception:
+                LOG.warning("Invalid %s=%r; using %s", name, raw, default)
+                return default
+
+        # The scheduler store MUST exist at the local per-project path.
+        # The daemon is spawned with cwd=projectRoot (ampa.mjs) so
+        # os.getcwd() gives the correct project root at startup.
+        store_path = os.path.join(
+            os.getcwd(), ".worklog", "ampa", "scheduler_store.json"
+        )
+        return SchedulerConfig(
+            poll_interval_seconds=_int("AMPA_SCHEDULER_POLL_INTERVAL_SECONDS", 5),
+            global_min_interval_seconds=_int(
+                "AMPA_SCHEDULER_GLOBAL_MIN_INTERVAL_SECONDS", 60
+            ),
+            priority_weight=_float("AMPA_SCHEDULER_PRIORITY_WEIGHT", 0.1),
+            store_path=store_path,
+            llm_healthcheck_url=os.getenv(
+                "AMPA_LLM_HEALTHCHECK_URL", "http://localhost:8000/health"
+            ),
+            max_run_history=_int("AMPA_SCHEDULER_MAX_RUN_HISTORY", 50),
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class RunResult:
+    start_ts: dt.datetime
+    end_ts: dt.datetime
+    exit_code: int
+    metadata: Optional[Dict[str, Any]] = dataclasses.field(default=None)
+
+    @property
+    def duration_seconds(self) -> float:
+        return (self.end_ts - self.start_ts).total_seconds()
+
+
+@dataclasses.dataclass(frozen=True)
+class CommandRunResult(RunResult):
+    output: str = ""

--- a/ampa/triage_audit.py
+++ b/ampa/triage_audit.py
@@ -22,6 +22,7 @@ try:
     from . import notifications as notifications_module
 except Exception:  # pragma: no cover - defensive
     import ampa.notifications as notifications_module
+from .scheduler_types import _utc_now, _to_iso, _from_iso
 
 LOG = logging.getLogger("ampa.triage_audit")
 
@@ -95,28 +96,6 @@ def _extract_summary_from_report(report: str) -> str:
     else:
         section = report[start:]
     return section.strip()
-
-
-def _utc_now() -> dt.datetime:
-    return dt.datetime.now(dt.timezone.utc)
-
-
-def _to_iso(value: Optional[dt.datetime]) -> Optional[str]:
-    if value is None:
-        return None
-    return value.isoformat()
-
-
-def _from_iso(value: Optional[str]) -> Optional[dt.datetime]:
-    if not value:
-        return None
-    try:
-        v = value
-        if isinstance(v, str) and v.endswith("Z"):
-            v = v[:-1] + "+00:00"
-        return dt.datetime.fromisoformat(v)
-    except Exception:
-        return None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bot_supervision.py
+++ b/tests/test_bot_supervision.py
@@ -16,9 +16,9 @@ from unittest import mock
 
 import pytest
 
+from ampa.scheduler_types import SchedulerConfig
 from ampa.scheduler import (
     Scheduler,
-    SchedulerConfig,
     SchedulerStore,
 )
 

--- a/tests/test_delegation_dispatch.py
+++ b/tests/test_delegation_dispatch.py
@@ -4,7 +4,8 @@ import datetime as dt
 from unittest.mock import MagicMock, patch
 
 from ampa import scheduler
-from ampa.scheduler import CommandSpec, SchedulerConfig, SchedulerStore, Scheduler
+from ampa.scheduler_types import CommandSpec, SchedulerConfig
+from ampa.scheduler import SchedulerStore, Scheduler
 from ampa import notifications as notifications_module
 from ampa.engine.core import EngineConfig, EngineResult, EngineStatus
 from ampa.engine.dispatch import DispatchResult

--- a/tests/test_delegation_output.py
+++ b/tests/test_delegation_output.py
@@ -2,11 +2,13 @@ import datetime as dt
 import json
 import subprocess
 
-from ampa.scheduler import (
+from ampa.scheduler_types import (
     CommandRunResult,
     CommandSpec,
-    Scheduler,
     SchedulerConfig,
+)
+from ampa.scheduler import (
+    Scheduler,
     SchedulerStore,
 )
 from ampa.engine.core import EngineConfig

--- a/tests/test_delegation_report_comprehensive.py
+++ b/tests/test_delegation_report_comprehensive.py
@@ -28,11 +28,13 @@ from ampa.delegation import (
     _format_in_progress_items,
     DelegationOrchestrator,
 )
-from ampa.scheduler import (
+from ampa.scheduler_types import (
     CommandRunResult,
     CommandSpec,
-    Scheduler,
     SchedulerConfig,
+)
+from ampa.scheduler import (
+    Scheduler,
     SchedulerStore,
 )
 from ampa import notifications as notifications_module

--- a/tests/test_delegation_report_dedup.py
+++ b/tests/test_delegation_report_dedup.py
@@ -13,14 +13,16 @@ import datetime as dt
 import json
 import subprocess
 
-from ampa.scheduler import (
+from ampa.scheduler_types import (
     CommandRunResult,
     CommandSpec,
-    Scheduler,
     SchedulerConfig,
-    SchedulerStore,
-    _content_hash,
 )
+from ampa.scheduler import (
+    Scheduler,
+    SchedulerStore,
+)
+from ampa.delegation import _content_hash
 from ampa import notifications as notifications_module
 from ampa.engine.core import EngineConfig
 from ampa.engine.dispatch import DispatchResult

--- a/tests/test_dry_run_reporting.py
+++ b/tests/test_dry_run_reporting.py
@@ -2,7 +2,8 @@ import json
 import json
 import subprocess
 
-from ampa.scheduler import Scheduler, SchedulerConfig, SchedulerStore, CommandSpec
+from ampa.scheduler_types import CommandSpec, SchedulerConfig
+from ampa.scheduler import Scheduler, SchedulerStore
 from ampa import notifications
 
 

--- a/tests/test_hung_child_recovery.py
+++ b/tests/test_hung_child_recovery.py
@@ -22,16 +22,18 @@ from unittest import mock
 
 import pytest
 
-from ampa.scheduler import (
+from ampa.scheduler_types import (
     CommandRunResult,
     CommandSpec,
     RunResult,
+    _utc_now,
+    _to_iso,
+)
+from ampa.scheduler import (
     Scheduler,
     SchedulerConfig,
     SchedulerStore,
     default_executor,
-    _utc_now,
-    _to_iso,
 )
 
 

--- a/tests/test_idle_delegation.py
+++ b/tests/test_idle_delegation.py
@@ -2,11 +2,13 @@ import json
 import subprocess
 import types
 
-from ampa.scheduler import (
+from ampa.scheduler_types import (
     CommandRunResult,
     CommandSpec,
-    Scheduler,
     SchedulerConfig,
+)
+from ampa.scheduler import (
+    Scheduler,
     SchedulerStore,
 )
 

--- a/tests/test_per_project_isolation.py
+++ b/tests/test_per_project_isolation.py
@@ -20,7 +20,8 @@ from unittest import mock
 import pytest
 
 from ampa.daemon import _project_ampa_dir, load_env
-from ampa.scheduler import SchedulerConfig, SchedulerStore
+from ampa.scheduler_types import SchedulerConfig
+from ampa.scheduler import SchedulerStore
 
 
 # ---------------------------------------------------------------------------
@@ -350,7 +351,7 @@ class TestSchedulerStoreIsolation:
         monkeypatch.chdir(project_a)
         config_a = SchedulerConfig.from_env()
         store_a = SchedulerStore(config_a.store_path)
-        from ampa.scheduler import CommandSpec
+        from ampa.scheduler_types import CommandSpec
 
         store_a.add_command(
             CommandSpec(
@@ -546,7 +547,7 @@ class TestCrossProjectContamination:
         store_b_before = json.loads(Path(path_b).read_text())
 
         # Mutate store A
-        from ampa.scheduler import CommandSpec
+        from ampa.scheduler_types import CommandSpec
 
         store_a.add_command(
             CommandSpec(

--- a/tests/test_scheduler_integration.py
+++ b/tests/test_scheduler_integration.py
@@ -12,11 +12,13 @@ from unittest import mock
 
 import pytest
 
-from ampa.scheduler import (
+from ampa.scheduler_types import (
     CommandSpec,
     RunResult,
-    Scheduler,
     SchedulerConfig,
+)
+from ampa.scheduler import (
+    Scheduler,
     SchedulerStore,
 )
 

--- a/tests/test_scheduler_list.py
+++ b/tests/test_scheduler_list.py
@@ -1,6 +1,7 @@
 import datetime as dt
 
-from ampa.scheduler import SchedulerStore, CommandSpec
+from ampa.scheduler_types import CommandSpec
+from ampa.scheduler import SchedulerStore
 from ampa.scheduler_cli import _build_command_listing
 
 

--- a/tests/test_scheduler_run.py
+++ b/tests/test_scheduler_run.py
@@ -8,12 +8,14 @@ import sys
 import threading
 from unittest import mock
 
-from ampa.scheduler import (
+from ampa.scheduler_types import (
     CommandRunResult,
     CommandSpec,
     RunResult,
-    Scheduler,
     SchedulerConfig,
+)
+from ampa.scheduler import (
+    Scheduler,
     SchedulerStore,
 )
 from ampa.scheduler_cli import (

--- a/tests/test_scheduler_scoring.py
+++ b/tests/test_scheduler_scoring.py
@@ -2,11 +2,13 @@ import datetime as dt
 import json
 import os
 
-from ampa.scheduler import (
+from ampa.scheduler_types import (
     CommandSpec,
     RunResult,
-    Scheduler,
     SchedulerConfig,
+)
+from ampa.scheduler import (
+    Scheduler,
     SchedulerStore,
 )
 

--- a/tests/test_scheduler_simulation.py
+++ b/tests/test_scheduler_simulation.py
@@ -1,11 +1,13 @@
 import datetime as dt
 import json
 
-from ampa.scheduler import (
+from ampa.scheduler_types import (
     CommandSpec,
     RunResult,
-    Scheduler,
     SchedulerConfig,
+)
+from ampa.scheduler import (
+    Scheduler,
     SchedulerStore,
 )
 

--- a/tests/test_stale_delegation_watchdog.py
+++ b/tests/test_stale_delegation_watchdog.py
@@ -26,15 +26,17 @@ from unittest import mock
 
 import pytest
 
-from ampa.scheduler import (
+from ampa.scheduler_types import (
     CommandRunResult,
     CommandSpec,
     RunResult,
+    _utc_now,
+    _to_iso,
+)
+from ampa.scheduler import (
     Scheduler,
     SchedulerConfig,
     SchedulerStore,
-    _utc_now,
-    _to_iso,
 )
 
 

--- a/tests/test_startup_message.py
+++ b/tests/test_startup_message.py
@@ -4,7 +4,8 @@ from types import SimpleNamespace
 import pytest
 
 import ampa.scheduler as sched_mod
-from ampa.scheduler import Scheduler, SchedulerStore, SchedulerConfig
+from ampa.scheduler_types import SchedulerConfig
+from ampa.scheduler import Scheduler, SchedulerStore
 
 
 def test_post_startup_message_uses_wl_status(tmp_path, monkeypatch):

--- a/tests/test_triage_audit.py
+++ b/tests/test_triage_audit.py
@@ -7,10 +7,9 @@ import re
 from types import SimpleNamespace
 
 from ampa import scheduler
+from ampa.scheduler_types import CommandSpec, SchedulerConfig
 from ampa.scheduler import (
     Scheduler,
-    CommandSpec,
-    SchedulerConfig,
     SchedulerStore,
 )
 import ampa.daemon as daemon


### PR DESCRIPTION
## Summary

- Extracts `CommandSpec`, `SchedulerConfig`, `RunResult`, `CommandRunResult` dataclasses and shared utility functions (`_utc_now`, `_to_iso`, `_from_iso`, `_seconds_between`, `_bool_meta`) from `scheduler.py` into a new `ampa/scheduler_types.py` module
- Updates all callers (`scheduler_cli.py`, `delegation.py`, `triage_audit.py`, 17 test files) to import from `scheduler_types` canonically
- `scheduler.py` re-exports all symbols for backward compatibility

## Motivation

This is the foundational extraction in the scheduler refactoring epic (SA-0MLXEKUGW0IYHTWG). Other extracted modules (delegation, triage-audit, store, executor) need these types but shouldn't depend on the full scheduler module. Having types in their own module eliminates circular import risks.

## Changes

| File | Change |
|------|--------|
| `ampa/scheduler_types.py` | **New** — canonical home for data classes and time/metadata utilities |
| `ampa/scheduler.py` | Removed inline definitions; imports + re-exports from `scheduler_types` |
| `ampa/scheduler_cli.py` | Types now imported from `scheduler_types` |
| `ampa/delegation.py` | Replaced local `_utc_now`/`_from_iso` copies and deferred imports with module-level imports from `scheduler_types` |
| `ampa/triage_audit.py` | Replaced local `_utc_now`/`_to_iso`/`_from_iso` copies with imports from `scheduler_types` |
| 17 test files | Updated to import from `ampa.scheduler_types` |

## Testing

All **897 tests pass** (3 skipped, 1 xfailed). Purely structural refactoring with no behavioral changes.

## Work Item

Closes SA-0MM36ESPX09ZLRG1 (child of SA-0MLXEKUGW0IYHTWG)