### PR TITLE
SA-0ML8RPAAO1RH7DAL: Remove container run/build docs and focus on CLI

### DIFF
--- a/ampa/README.md
+++ b/ampa/README.md
@@ -507,3 +507,11 @@ MVP validation of the interactive buttons feature. The command can be run manual
 ```bash
 python -m ampa.scheduler run-once test-button
 ```
+
+Project References
+------------------
+
+- PRD: `docs/prd/PRD_Automated_PM_Agent_-_end-to-end_project_overseer_(SA-0ML5E2A2V1YILTVR).md`
+- Parent epic: SA-0ML5E2A2V1YILTVR (Automated PM Agent — end-to-end project overseer)
+- Parent work item: SA-0ML7NOSHP0MJC6HS (AMPA Daemon: Discord heartbeat & notifier)
+- Documentation work item: SA-0ML7OB1H71YWK6OG (Documentation & Operator Runbook)


### PR DESCRIPTION
## Summary

Finalizes work item SA-0ML8RPAAO1RH7DAL by ensuring all container build/run documentation and artifacts are removed and the README focuses on CLI usage.

## What was done

- **Container artifacts removed** (in earlier commits): `ampa/Dockerfile`, `ampa/README_CONTAINER.md`, `ampa/Makefile`, `ampa/scripts/run.sh` were all deleted as part of the scheduler daemon work (commit 4cc8e3a).
- **README updated to CLI-first**: `ampa/README.md` focuses on `python -m ampa.daemon` and `python -m ampa.scheduler` for operator usage.
- **Developer container section preserved**: The README includes a clearly scoped "Developer-only container (for contributors)" section referencing `ampa/Containerfile` for dev workflows only, with explicit disclaimers that container instructions are not for operator deployments.
- **Project references added**: This commit adds project reference links to the bottom of the README.
- **No lingering references**: Verified via repo-wide search that no references to removed artifacts (Dockerfile, README_CONTAINER.md, Makefile, scripts/run.sh) remain in tracked source files.

## Acceptance criteria verification

- [x] Container build/run instructions are removed from docs
- [x] Container-specific helper scripts/Makefile content are removed or deprecated as appropriate
- [x] CLI run instructions for the scheduler are preserved/updated

## Test results

All 962 tests pass (1 xfailed).

## Review focus

- Verify the README content at `ampa/README.md` reads clearly for operators (CLI-first) and contributors (dev container section)
- Confirm the project references section at the bottom is useful and accurate

## Work item

- SA-0ML8RPAAO1RH7DAL
- Related: discovered-from SA-0ML7Q2XI11OO3S5I