### PR TITLE
SA-0MM4LOAAP1M3QQLC: Migrate webhook references to bot-token/notification terminology

### DIFF
--- a/ampa/discord_bot.py
+++ b/ampa/discord_bot.py
@@ -2,8 +2,7 @@
 
 This module implements a Discord bot that listens on a Unix domain socket for
 incoming notification requests and sends them as messages to a configured
-Discord channel.  It replaces the webhook-based notification system with a
-persistent bot connection.
+Discord channel.
 
 Usage::
 
@@ -17,8 +16,8 @@ Environment variables:
 
 The bot accepts newline-delimited JSON messages on the Unix socket.  Each
 message must be a JSON object; it is sent to the configured Discord channel as
-a plain-text message using the ``content`` field (matching the existing webhook
-payload format ``{"content": "..."}``) .
+a plain-text message using the ``content`` field
+(payload format ``{"content": "..."}``) .
 
 Protocol
 --------
@@ -380,7 +379,7 @@ class AMPABot:
                     await writer.drain()
                     continue
 
-                # Extract the message content.  Accept either the webhook-style
+                # Extract the message content.  Accept either the
                 # ``{"content": "..."}`` format or a ``{"body": "...", "title":
                 # "..."}`` format from the notification API.
                 content = data.get("content")

--- a/ampa/notifications.py
+++ b/ampa/notifications.py
@@ -1,8 +1,8 @@
 """Public notification API for AMPA.
 
 This module provides a single entry point — :func:`notify` — that all AMPA
-modules should call instead of ``webhook_module.send_webhook()``.  Internally
-it routes messages to the Discord bot via a Unix domain socket.
+modules should call to send Discord messages.  Internally it routes messages
+to the Discord bot via a Unix domain socket.
 
 If the socket is unreachable the message is dead-lettered to a local file so
 nothing is silently lost.
@@ -10,9 +10,9 @@ nothing is silently lost.
 State tracking
 --------------
 Each successful send records ``last_message_ts`` and ``last_message_type`` in a
-state file (same path as the legacy webhook state).  The daemon's heartbeat
-suppression logic reads this state to avoid sending redundant heartbeats when
-a non-heartbeat message was already sent recently.
+state file.  The daemon's heartbeat suppression logic reads this state to avoid
+sending redundant heartbeats when a non-heartbeat message was already sent
+recently.
 """
 
 from __future__ import annotations
@@ -40,8 +40,8 @@ DEFAULT_BACKOFF_BASE_SECONDS = 2.0
 
 
 # ---------------------------------------------------------------------------
-# State helpers (ported from webhook.py so the state-file contract is
-# preserved across the migration).
+# State helpers — the state-file contract is preserved for backward
+# compatibility.
 # ---------------------------------------------------------------------------
 
 
@@ -68,7 +68,7 @@ def _state_file_path() -> str:
 
 
 # ---------------------------------------------------------------------------
-# Dead-letter (ported from webhook.py)
+# Dead-letter
 # ---------------------------------------------------------------------------
 
 
@@ -105,7 +105,7 @@ def dead_letter(payload: Dict[str, Any], reason: Optional[str] = None) -> None:
             "payload": payload,
         }
 
-        # If a webhook is configured, try to POST the dead-letter record.
+        # If a dead-letter webhook is configured, try to POST the record there.
         webhook = os.getenv("AMPA_DEADLETTER_WEBHOOK")
         if webhook:
             try:
@@ -119,11 +119,14 @@ def dead_letter(payload: Dict[str, Any], reason: Optional[str] = None) -> None:
                     # Raise for status to treat non-2xx as failures.
                     try:
                         resp.raise_for_status()
-                        LOG.info("dead_letter: posted failure to webhook %s", webhook)
+                        LOG.info(
+                            "dead_letter: posted failure to dead-letter webhook %s",
+                            webhook,
+                        )
                         return
                     except Exception:
                         LOG.exception(
-                            "dead_letter: webhook POST returned non-2xx status (%s)",
+                            "dead_letter: dead-letter webhook POST returned non-2xx status (%s)",
                             getattr(resp, "status_code", None),
                         )
                 finally:
@@ -136,7 +139,9 @@ def dead_letter(payload: Dict[str, Any], reason: Optional[str] = None) -> None:
                     "dead_letter: requests library not available, falling back to file"
                 )
             except Exception:
-                LOG.exception("dead_letter: webhook POST failed, falling back to file")
+                LOG.exception(
+                    "dead_letter: dead-letter webhook POST failed, falling back to file"
+                )
 
         # Fallback: append to the dead-letter file.
         dl_file = os.getenv("AMPA_DEADLETTER_FILE") or _default_deadletter_path()
@@ -157,9 +162,8 @@ def dead_letter(payload: Dict[str, Any], reason: Optional[str] = None) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Payload builders (ported from webhook.py for backward compatibility during
-# migration — callers can continue to use these to build the message content
-# and then pass the result to notify()).
+# Payload builders — callers can use these to build the message content
+# and then pass the result to notify().
 # ---------------------------------------------------------------------------
 
 
@@ -176,10 +180,10 @@ def build_payload(
     extra_fields: Optional[List[Dict[str, Any]]] = None,
     title: str = "AMPA Heartbeat",
 ) -> Dict[str, Any]:
-    """Build a simple markdown payload (same output as ``webhook.build_payload``).
+    """Build a simple markdown payload (same output as the legacy ``build_payload``).
 
-    Returns ``{"content": "<markdown>"}`` — compatible with both the legacy
-    webhook format and the new bot socket protocol.
+    Returns ``{"content": "<markdown>"}`` — compatible with the bot socket
+    protocol.
     """
     heading = f"# {title}"
     body: List[str] = []
@@ -204,7 +208,7 @@ def build_command_payload(
     exit_code: Optional[int],
     title: str = "AMPA Heartbeat",
 ) -> Dict[str, Any]:
-    """Build a command-oriented payload (same as ``webhook.build_command_payload``).
+    """Build a command-oriented payload (same as the legacy ``build_command_payload``).
 
     Returns ``{"content": "<markdown>"}``.
     """

--- a/tests/install-worklog-plugin.bats
+++ b/tests/install-worklog-plugin.bats
@@ -235,7 +235,7 @@ teardown() {
   [ -f ".worklog/plugins/ampa_py/ampa/.env" ]
 }
 
-@test "webhook written to env file" {
+@test "bot token and channel id written to env file" {
   mkdir -p ampa
   echo 'AMPA_DISCORD_BOT_TOKEN=""' > ampa/.env.sample
   echo 'AMPA_DISCORD_CHANNEL_ID=""' >> ampa/.env.sample

--- a/tests/test_delegation_dispatch.py
+++ b/tests/test_delegation_dispatch.py
@@ -43,13 +43,13 @@ def make_scheduler(run_shell_callable, tmp_path):
 
 
 def test_dispatch_logged_before_spawn(tmp_path, monkeypatch):
-    """Verify a dispatch record is persisted and a dispatch webhook is sent
+    """Verify a dispatch record is persisted and a dispatch notification is sent
     when the engine successfully dispatches work.
 
     The engine records the dispatch after spawning the subprocess (via
     ``StoreDispatchRecorder``). This test patches the engine's dispatcher to
     avoid real subprocess spawning and verifies that the full delegation
-    flow (inspect → engine dispatch → record → webhook) works end-to-end.
+    flow (inspect → engine dispatch → record → notification) works end-to-end.
     """
     calls = []
     captured = {"calls": []}

--- a/tests/test_delegation_report_comprehensive.py
+++ b/tests/test_delegation_report_comprehensive.py
@@ -533,10 +533,10 @@ class TestIntegrationIdleNoCandidates:
 
     def test_all_rejected_discord_notification(self, tmp_path, monkeypatch):
         """Discord notification sent with idle content when all candidates rejected."""
-        webhook_calls = []
+        notify_calls = []
 
         def fake_notify(title, body="", message_type="other", *, payload=None):
-            webhook_calls.append({"title": title, "body": body, "type": message_type})
+            notify_calls.append({"title": title, "body": body, "type": message_type})
             return True
 
         fake_mod = types.SimpleNamespace(notify=fake_notify)
@@ -585,7 +585,7 @@ class TestIntegrationIdleNoCandidates:
         sched = _make_scheduler(fake_run_shell, tmp_path)
         sched.start_command(_delegation_spec())
 
-        command_calls = [c for c in webhook_calls if c["type"] == "command"]
+        command_calls = [c for c in notify_calls if c["type"] == "command"]
         assert len(command_calls) >= 1, "Should send at least one notification"
         # The notification body should reflect idle state, not busy
         for call in command_calls:
@@ -594,10 +594,10 @@ class TestIntegrationIdleNoCandidates:
     def test_no_items_message_not_busy_in_report(self, tmp_path, monkeypatch):
         """The pre-dispatch report uses idle format when wl in_progress says
         'No in-progress work items found'."""
-        webhook_calls = []
+        notify_calls = []
 
         def fake_notify(title, body="", message_type="other", *, payload=None):
-            webhook_calls.append({"title": title, "body": body, "type": message_type})
+            notify_calls.append({"title": title, "body": body, "type": message_type})
             return True
 
         fake_mod = types.SimpleNamespace(notify=fake_notify)
@@ -646,7 +646,7 @@ class TestIntegrationIdleNoCandidates:
         sched = _make_scheduler(fake_run_shell, tmp_path)
         sched.start_command(_delegation_spec())
 
-        command_calls = [c for c in webhook_calls if c["type"] == "command"]
+        command_calls = [c for c in notify_calls if c["type"] == "command"]
         assert len(command_calls) >= 1
         body = command_calls[0]["body"]
         assert "Agents are currently busy" not in body
@@ -808,10 +808,10 @@ class TestIntegrationInvariantFailure:
 
     def test_invariant_failure_discord_has_detail(self, tmp_path, monkeypatch):
         """Discord notification includes detail, not 'busy', when invariant fails."""
-        webhook_calls = []
+        notify_calls = []
 
         def fake_notify(title, body="", message_type="other", *, payload=None):
-            webhook_calls.append({"title": title, "body": body, "type": message_type})
+            notify_calls.append({"title": title, "body": body, "type": message_type})
             return True
 
         fake_mod = types.SimpleNamespace(notify=fake_notify)
@@ -877,7 +877,7 @@ class TestIntegrationInvariantFailure:
         sched.start_command(_delegation_spec())
 
         # At least one command-type notification should have been sent
-        command_calls = [c for c in webhook_calls if c["type"] == "command"]
+        command_calls = [c for c in notify_calls if c["type"] == "command"]
         assert len(command_calls) >= 1, "At least one Discord notification expected"
         # No notification should say "Agents are currently busy" when agents are idle
         for call in command_calls:

--- a/tests/test_delegation_report_dedup.py
+++ b/tests/test_delegation_report_dedup.py
@@ -182,10 +182,10 @@ def _make_in_progress_shell(in_progress_text):
 
 def test_first_report_always_sent(tmp_path, monkeypatch):
     """AC (a): The very first delegation report should always be sent."""
-    webhook_calls = []
+    notify_calls = []
 
     def fake_notify(title, body="", message_type="other", *, payload=None):
-        webhook_calls.append(
+        notify_calls.append(
             {"title": title, "body": body, "message_type": message_type}
         )
         return 204
@@ -199,17 +199,17 @@ def test_first_report_always_sent(tmp_path, monkeypatch):
 
     sched.start_command(spec)
 
-    # The pre-dispatch report webhook should have been sent
-    command_calls = [c for c in webhook_calls if c["message_type"] == "command"]
+    # The pre-dispatch report notification should have been sent
+    command_calls = [c for c in notify_calls if c["message_type"] == "command"]
     assert len(command_calls) >= 1, "First report should be sent to Discord"
 
 
 def test_identical_report_suppressed(tmp_path, monkeypatch):
     """AC (b): Identical consecutive reports should be suppressed."""
-    webhook_calls = []
+    notify_calls = []
 
     def fake_notify(title, body="", message_type="other", *, payload=None):
-        webhook_calls.append(
+        notify_calls.append(
             {"title": title, "body": body, "message_type": message_type}
         )
         return 204
@@ -223,12 +223,12 @@ def test_identical_report_suppressed(tmp_path, monkeypatch):
 
     # First run: should send
     sched.start_command(spec)
-    first_count = len([c for c in webhook_calls if c["message_type"] == "command"])
+    first_count = len([c for c in notify_calls if c["message_type"] == "command"])
     assert first_count >= 1
 
-    # Second run with identical content: should NOT send additional webhooks
+    # Second run with identical content: should NOT send additional notifications
     sched.start_command(spec)
-    second_count = len([c for c in webhook_calls if c["message_type"] == "command"])
+    second_count = len([c for c in notify_calls if c["message_type"] == "command"])
     assert second_count == first_count, (
         f"Duplicate report should be suppressed; "
         f"expected {first_count} but got {second_count}"
@@ -237,10 +237,10 @@ def test_identical_report_suppressed(tmp_path, monkeypatch):
 
 def test_changed_report_sent(tmp_path, monkeypatch):
     """AC (c): Report with different content should be sent."""
-    webhook_calls = []
+    notify_calls = []
 
     def fake_notify(title, body="", message_type="other", *, payload=None):
-        webhook_calls.append(
+        notify_calls.append(
             {"title": title, "body": body, "message_type": message_type}
         )
         return 204
@@ -253,7 +253,7 @@ def test_changed_report_sent(tmp_path, monkeypatch):
     sched = _make_scheduler(shell1, tmp_path)
     spec = _delegation_spec()
     sched.start_command(spec)
-    first_count = len([c for c in webhook_calls if c["message_type"] == "command"])
+    first_count = len([c for c in notify_calls if c["message_type"] == "command"])
     assert first_count >= 1
 
     # Now change the in-progress items -> different report content
@@ -283,7 +283,7 @@ def test_changed_report_sent(tmp_path, monkeypatch):
     sched.run_shell = shell2
 
     sched.start_command(spec)
-    second_count = len([c for c in webhook_calls if c["message_type"] == "command"])
+    second_count = len([c for c in notify_calls if c["message_type"] == "command"])
     assert second_count > first_count, "Changed report should be sent to Discord"
 
 
@@ -294,10 +294,10 @@ def test_changed_report_sent(tmp_path, monkeypatch):
 
 def test_idle_no_candidate_dedup(tmp_path, monkeypatch):
     """Idle 'no candidate' messages should be deduped on consecutive runs."""
-    webhook_calls = []
+    notify_calls = []
 
     def fake_notify(title, body="", message_type="other", *, payload=None):
-        webhook_calls.append({"message_type": message_type})
+        notify_calls.append({"message_type": message_type})
         return 204
 
     monkeypatch.setattr(notifications_module, "notify", fake_notify)
@@ -330,11 +330,11 @@ def test_idle_no_candidate_dedup(tmp_path, monkeypatch):
 
     # First run
     sched.start_command(spec)
-    first_count = len([c for c in webhook_calls if c["message_type"] == "command"])
+    first_count = len([c for c in notify_calls if c["message_type"] == "command"])
 
     # Second run with same state
     sched.start_command(spec)
-    second_count = len([c for c in webhook_calls if c["message_type"] == "command"])
+    second_count = len([c for c in notify_calls if c["message_type"] == "command"])
 
     assert second_count == first_count, "Duplicate idle message should be suppressed"
 
@@ -346,10 +346,10 @@ def test_idle_no_candidate_dedup(tmp_path, monkeypatch):
 
 def test_dispatch_notification_always_sent(tmp_path, monkeypatch):
     """Dispatch notifications (message_type='dispatch') should not be suppressed."""
-    webhook_calls = []
+    notify_calls = []
 
     def fake_notify(title, body="", message_type="other", *, payload=None):
-        webhook_calls.append(
+        notify_calls.append(
             {"title": title, "body": body, "message_type": message_type}
         )
         return 204
@@ -430,10 +430,10 @@ def test_dispatch_notification_always_sent(tmp_path, monkeypatch):
     # Run twice; dispatch notification should appear both times.
     # The engine sends dispatch notifications with message_type="engine".
     sched.start_command(spec)
-    first_dispatch = len([c for c in webhook_calls if c["message_type"] == "engine"])
+    first_dispatch = len([c for c in notify_calls if c["message_type"] == "engine"])
 
     sched.start_command(spec)
-    second_dispatch = len([c for c in webhook_calls if c["message_type"] == "engine"])
+    second_dispatch = len([c for c in notify_calls if c["message_type"] == "engine"])
 
     assert first_dispatch >= 1, "Dispatch notification should be sent on first run"
     assert second_dispatch >= 2, (

--- a/tests/test_idle_delegation.py
+++ b/tests/test_idle_delegation.py
@@ -61,7 +61,7 @@ def _delegation_spec():
     )
 
 
-def test_idle_delegation_posts_single_detailed_webhook(tmp_path, monkeypatch):
+def test_idle_delegation_posts_single_detailed_notification(tmp_path, monkeypatch):
     calls = []
 
     def fake_notify(title, body="", message_type="other", *, payload=None):
@@ -109,7 +109,7 @@ def test_idle_delegation_posts_single_detailed_webhook(tmp_path, monkeypatch):
 
     result_run = sched.start_command(spec)
 
-    # Ensure a detailed idle webhook is sent. When all candidates are
+    # Ensure a detailed idle notification is sent. When all candidates are
     # rejected the pre-dispatch report path runs and sends a report
     # that includes the considered candidates.
     assert len(calls) >= 1, "Expected at least one notification to be sent"

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -92,7 +92,7 @@ def _run_sync_in_async(sync_fn, *args, **kwargs):
 
 
 # ---------------------------------------------------------------------------
-# Tests: payload builders (identical to webhook.py behavior)
+# Tests: payload builders
 # ---------------------------------------------------------------------------
 
 
@@ -225,7 +225,9 @@ class TestDeadLetter:
         record = json.loads(open(custom_file).readline())
         assert record["payload"]["content"] == "override"
 
-    def test_posts_to_webhook_and_does_not_write_file(self, tmp_path, monkeypatch):
+    def test_posts_to_deadletter_webhook_and_does_not_write_file(
+        self, tmp_path, monkeypatch
+    ):
         """When AMPA_DEADLETTER_WEBHOOK is set and POST succeeds, no file write."""
         dl_file = str(tmp_path / "dead.log")
         monkeypatch.setenv("AMPA_DEADLETTER_FILE", dl_file)
@@ -257,21 +259,21 @@ class TestDeadLetter:
 
         monkeypatch.setattr(requests, "Session", _Session)
 
-        dead_letter({"content": "from-webhook"}, reason="socket down")
+        dead_letter({"content": "dead-letter-test"}, reason="socket down")
 
         # POST attempted
         assert posted.get("url") == "http://example.invalid/hook"
         assert posted.get("json") is not None
         assert posted["json"]["reason"] == "socket down"
-        assert posted["json"]["payload"]["content"] == "from-webhook"
+        assert posted["json"]["payload"]["content"] == "dead-letter-test"
 
-        # File should not be written when webhook accepted the record
+        # File should not be written when dead-letter webhook accepted the record
         assert not os.path.exists(dl_file)
 
-    def test_webhook_post_failure_falls_back_to_file(
+    def test_deadletter_webhook_post_failure_falls_back_to_file(
         self, tmp_path, monkeypatch, caplog
     ):
-        """When webhook POST fails, dead_letter falls back to file and logs error."""
+        """When dead-letter webhook POST fails, dead_letter falls back to file and logs error."""
         dl_file = str(tmp_path / "dead.log")
         monkeypatch.setenv("AMPA_DEADLETTER_FILE", dl_file)
         monkeypatch.setenv("AMPA_DEADLETTER_WEBHOOK", "http://example.invalid/hook")
@@ -305,12 +307,13 @@ class TestDeadLetter:
         assert record["reason"] == "socket down"
         assert record["payload"]["content"] == "fallback"
 
-        # Ensure error was logged about webhook failure
+        # Ensure error was logged about dead-letter webhook failure
         found = False
         for rec in caplog.records:
             if (
-                "dead_letter: webhook POST returned non-2xx status" in rec.getMessage()
-                or "dead_letter: webhook POST failed" in rec.getMessage()
+                "dead_letter: dead-letter webhook POST returned non-2xx status"
+                in rec.getMessage()
+                or "dead_letter: dead-letter webhook POST failed" in rec.getMessage()
             ):
                 found = True
                 break

--- a/tests/test_scheduler_integration.py
+++ b/tests/test_scheduler_integration.py
@@ -743,7 +743,7 @@ class TestShellAdapters:
         recorder = StoreDispatchRecorder(store=failing_store)
         assert recorder.record_dispatch({}) is None
 
-    def test_discord_notification_sender_no_webhook(self):
+    def test_discord_notification_sender_no_bot_token(self):
         from ampa.engine.adapters import DiscordNotificationSender
 
         with mock.patch("ampa.notifications.notify", return_value=True):

--- a/tests/test_stale_delegation_watchdog.py
+++ b/tests/test_stale_delegation_watchdog.py
@@ -577,7 +577,7 @@ class TestThresholdConfiguration:
 
 
 class TestDiscordNotification:
-    """Verify Discord webhook is sent on recovery."""
+    """Verify Discord notification is sent on recovery."""
 
     def test_discord_sent_on_recovery(self, monkeypatch):
         """A notification is sent when items are recovered."""

--- a/tests/test_triage_audit.py
+++ b/tests/test_triage_audit.py
@@ -1042,11 +1042,11 @@ def test_structured_audit_end_to_end(tmp_path, monkeypatch):
     Verifies:
     1. The posted WL comment contains the structured report (not raw output).
     2. The posted WL comment does NOT contain the old "Audit output:" label.
-    3. The Discord webhook payload includes the summary extracted from ## Summary.
+    3. The Discord notification payload includes the summary extracted from ## Summary.
     4. Preamble/trailing noise from the raw output is excluded from the comment.
     """
     calls = []
-    webhook_payloads = []
+    notify_payloads = []
     posted_comments = []
     work_id = "TEST-E2E-STRUCT-001"
 
@@ -1078,7 +1078,7 @@ def test_structured_audit_end_to_end(tmp_path, monkeypatch):
 
     def capture_notify(title, body="", message_type="other", *, payload=None):
         if payload is not None:
-            webhook_payloads.append(payload)
+            notify_payloads.append(payload)
         return True
 
     monkeypatch.setattr(notifications, "notify", capture_notify)
@@ -1171,8 +1171,8 @@ def test_structured_audit_end_to_end(tmp_path, monkeypatch):
     assert "--- AUDIT REPORT START ---" not in comment_content
     assert "--- AUDIT REPORT END ---" not in comment_content
 
-    # --- Verify Discord webhook ---
-    assert webhook_payloads, "Expected at least one webhook payload"
-    # The webhook should include the Summary section text
-    payload_str = json.dumps(webhook_payloads[0])
+    # --- Verify Discord notification ---
+    assert notify_payloads, "Expected at least one notification payload"
+    # The notification should include the Summary section text
+    payload_str = json.dumps(notify_payloads[0])
     assert "All 3 acceptance criteria are met" in payload_str


### PR DESCRIPTION
## Summary

Replaces vestigial webhook-era naming (variable names, function names, comments, docstrings) across installer tests and source code with bot-token/notification terminology, reflecting the already-completed migration from Discord webhooks to the bot/token model.

**Work item:** SA-0MM4LOAAP1M3QQLC

## Changes

### Test files (9 files)
- `tests/install-worklog-plugin.bats` — Renamed test "webhook written to env file" → "bot token and channel id written to env file"
- `tests/test_idle_delegation.py` — Renamed function `…_webhook` → `…_notification`; updated comment
- `tests/test_scheduler_integration.py` — Renamed method `…_no_webhook` → `…_no_bot_token`
- `tests/test_delegation_report_comprehensive.py` — Renamed `webhook_calls` → `notify_calls`
- `tests/test_delegation_report_dedup.py` — Renamed `webhook_calls` → `notify_calls`; updated comments
- `tests/test_triage_audit.py` — Renamed `webhook_payloads` → `notify_payloads`; updated comments/asserts
- `tests/test_delegation_dispatch.py` — Updated docstring
- `tests/test_stale_delegation_watchdog.py` — Updated docstring
- `tests/test_notifications.py` — Renamed test functions to clarify dead-letter webhook vs generic webhook; updated comments and log assertions

### Source files (2 files)
- `ampa/notifications.py` — Removed stale webhook-system references from docstrings/comments; clarified dead-letter log messages
- `ampa/discord_bot.py` — Removed stale "replaces webhook" references from module docstring

## What was NOT changed (intentionally)
- `AMPA_DEADLETTER_WEBHOOK` env var and dead-letter webhook code — this is a separate, intentional feature
- `docs/workflow/examples/*.md` — these reference payment webhooks, not Discord notifications
- `docs/triage-audit.md`, `reports/` — historical/informational references
- `docs/workflow/workflow-schema.json` — "webhook" is a valid notification channel type

## Testing
- All 962 tests pass (1 expected failure), no regressions
- No functional changes — purely naming/documentation cleanup