### PR TITLE
SA-0MM8SJKC31N0PQ55: Enforce subprocess timeout in ContainerDispatcher

### DIFF
--- a/ampa/engine/dispatch.py
+++ b/ampa/engine/dispatch.py
@@ -24,8 +24,10 @@ from __future__ import annotations
 import json
 import logging
 import os
+import signal
 import subprocess
 import sys
+import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -226,6 +228,54 @@ class OpenCodeRunDispatcher:
 
 # Default timeout (seconds) for the distrobox-enter subprocess.
 _DEFAULT_CONTAINER_DISPATCH_TIMEOUT = 30
+
+# Grace period (seconds) between SIGTERM and SIGKILL during timeout enforcement.
+_TIMEOUT_GRACE_PERIOD = 5
+
+
+def _enforce_timeout(proc: subprocess.Popen, timeout: int) -> None:
+    """Kill *proc* after *timeout* seconds if it is still running.
+
+    Runs as a daemon-thread callback so ``dispatch()`` can return immediately
+    (fire-and-forget contract).  Because the child is started with
+    ``start_new_session=True`` we use ``os.killpg`` to terminate the entire
+    process group, ensuring any children spawned inside the distrobox
+    container are also cleaned up.
+
+    Escalation sequence (mirrors ``BotSupervisor.shutdown``):
+      1. ``SIGTERM`` the process group.
+      2. Wait up to ``_TIMEOUT_GRACE_PERIOD`` seconds for graceful exit.
+      3. ``SIGKILL`` the process group if still alive.
+    """
+    exit_code = proc.poll()
+    if exit_code is not None:
+        # Already exited — nothing to do.
+        return
+
+    pgid = proc.pid  # process group id == pid when start_new_session=True
+    LOG.warning(
+        "Container dispatch timeout (%ds) reached for pid %d — sending SIGTERM",
+        timeout,
+        proc.pid,
+    )
+
+    try:
+        os.killpg(pgid, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError):
+        return  # Already gone or we lack permission — nothing more to do.
+
+    try:
+        proc.wait(timeout=_TIMEOUT_GRACE_PERIOD)
+    except subprocess.TimeoutExpired:
+        LOG.warning(
+            "Container dispatch pid %d did not exit after SIGTERM + %ds grace — sending SIGKILL",
+            proc.pid,
+            _TIMEOUT_GRACE_PERIOD,
+        )
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass  # Already gone.
 
 
 def _global_ampa_dir() -> Path:
@@ -481,11 +531,22 @@ class ContainerDispatcher:
                 container_id=container_name,
             )
 
+        # 4. Schedule timeout enforcement -----------------------------------
+        if self._timeout and self._timeout > 0:
+            timer = threading.Timer(
+                self._timeout,
+                _enforce_timeout,
+                args=(proc, self._timeout),
+            )
+            timer.daemon = True  # Don't prevent engine shutdown.
+            timer.start()
+
         LOG.info(
-            "Container dispatch successful: %s -> container=%s pid=%d",
+            "Container dispatch successful: %s -> container=%s pid=%d timeout=%ds",
             work_item_id,
             container_name,
             proc.pid,
+            self._timeout,
         )
         return DispatchResult(
             success=True,

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import json
+import os
+import signal
 import subprocess
+import threading
 from datetime import datetime, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -16,6 +19,7 @@ from ampa.engine.dispatch import (
     Dispatcher,
     DryRunDispatcher,
     OpenCodeRunDispatcher,
+    _enforce_timeout,
 )
 
 # ---------------------------------------------------------------------------
@@ -736,6 +740,116 @@ class TestContainerDispatcherTimeout:
         """Invalid env var falls back to constructor / default."""
         d = ContainerDispatcher(timeout=45, clock=_fixed_clock)
         assert d._timeout == 45
+
+    @patch(f"{_POOL_MOD}.subprocess.Popen")
+    @patch(f"{_POOL_MOD}._claim_pool_container", return_value="ampa-pool-0")
+    @patch(f"{_POOL_MOD}.threading.Timer")
+    def test_dispatch_starts_timer(self, mock_timer_cls, mock_claim, mock_popen):
+        """dispatch() starts a daemon Timer with the configured timeout."""
+        mock_proc = MagicMock()
+        mock_proc.pid = 9999
+        mock_popen.return_value = mock_proc
+        mock_timer = MagicMock()
+        mock_timer_cls.return_value = mock_timer
+
+        d = ContainerDispatcher(
+            project_root="/proj",
+            timeout=42,
+            clock=_fixed_clock,
+        )
+        result = d.dispatch(command="cmd", work_item_id="WL-TMR")
+
+        assert result.success is True
+        mock_timer_cls.assert_called_once()
+        timer_args = mock_timer_cls.call_args
+        assert timer_args[1]["args"] == (mock_proc, 42) or timer_args[0][2] == (
+            mock_proc,
+            42,
+        )
+        assert mock_timer.daemon is True
+        mock_timer.start.assert_called_once()
+
+
+class TestEnforceTimeout:
+    """Tests for _enforce_timeout helper function."""
+
+    def test_already_exited_does_nothing(self):
+        """If process already exited, _enforce_timeout is a no-op."""
+        proc = MagicMock()
+        proc.poll.return_value = 0  # Already exited.
+
+        with patch(f"{_POOL_MOD}.os.killpg") as mock_killpg:
+            _enforce_timeout(proc, 30)
+
+        mock_killpg.assert_not_called()
+
+    @patch(f"{_POOL_MOD}.os.killpg")
+    def test_sends_sigterm_to_process_group(self, mock_killpg):
+        """Sends SIGTERM to the process group when process is still running."""
+        proc = MagicMock()
+        proc.pid = 12345
+        proc.poll.return_value = None  # Still running.
+        proc.wait.return_value = 0  # Exits after SIGTERM.
+
+        _enforce_timeout(proc, 30)
+
+        mock_killpg.assert_called_once_with(12345, signal.SIGTERM)
+
+    @patch(f"{_POOL_MOD}.os.killpg")
+    def test_escalates_to_sigkill_on_timeout(self, mock_killpg):
+        """Sends SIGKILL if process doesn't exit after SIGTERM + grace period."""
+        proc = MagicMock()
+        proc.pid = 12345
+        proc.poll.return_value = None  # Still running.
+        proc.wait.side_effect = subprocess.TimeoutExpired(cmd="cmd", timeout=5)
+
+        _enforce_timeout(proc, 30)
+
+        assert mock_killpg.call_count == 2
+        mock_killpg.assert_any_call(12345, signal.SIGTERM)
+        mock_killpg.assert_any_call(12345, signal.SIGKILL)
+
+    @patch(f"{_POOL_MOD}.os.killpg")
+    def test_handles_process_already_gone_on_sigterm(self, mock_killpg):
+        """ProcessLookupError on SIGTERM is handled gracefully."""
+        proc = MagicMock()
+        proc.pid = 12345
+        proc.poll.return_value = None
+        mock_killpg.side_effect = ProcessLookupError
+
+        # Should not raise.
+        _enforce_timeout(proc, 30)
+
+        mock_killpg.assert_called_once_with(12345, signal.SIGTERM)
+
+    @patch(f"{_POOL_MOD}.os.killpg")
+    def test_handles_process_already_gone_on_sigkill(self, mock_killpg):
+        """ProcessLookupError on SIGKILL (after SIGTERM) is handled gracefully."""
+        proc = MagicMock()
+        proc.pid = 12345
+        proc.poll.return_value = None
+        proc.wait.side_effect = subprocess.TimeoutExpired(cmd="cmd", timeout=5)
+
+        # First call (SIGTERM) succeeds, second call (SIGKILL) raises.
+        mock_killpg.side_effect = [None, ProcessLookupError]
+
+        # Should not raise.
+        _enforce_timeout(proc, 30)
+
+        assert mock_killpg.call_count == 2
+
+    @patch(f"{_POOL_MOD}.os.killpg")
+    def test_handles_permission_error_on_sigterm(self, mock_killpg):
+        """PermissionError on SIGTERM is handled gracefully."""
+        proc = MagicMock()
+        proc.pid = 12345
+        proc.poll.return_value = None
+        mock_killpg.side_effect = PermissionError
+
+        # Should not raise.
+        _enforce_timeout(proc, 30)
+
+        mock_killpg.assert_called_once_with(12345, signal.SIGTERM)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `_enforce_timeout()` daemon-thread callback that sends SIGTERM to the container process group after the configured timeout, waits a 5-second grace period, then escalates to SIGKILL if the process is still alive
- Wires timeout enforcement into `ContainerDispatcher.dispatch()` via `threading.Timer`, closing the gap where `_timeout` was parsed from `AMPA_CONTAINER_DISPATCH_TIMEOUT` but never applied to the spawned subprocess
- Adds 7 new tests covering: already-exited no-op, SIGTERM delivery, SIGKILL escalation, ProcessLookupError/PermissionError resilience, and dispatch() timer integration

## Context

Work item SA-0MM8SJKC31N0PQ55 — "Resolve stale container-dispatch branches and close associated work items."

As part of this work:
- Stale branches `feature/SA-0MM3CMKBQ1454E0E-container-aware-dispatch-result` and `feature/SA-0MM3CMZZD1K61ETX-container-dispatcher` were deleted (local + remote) — both were already merged via PR #455
- Work item SA-0MM3CMKBQ1454E0E was closed (already merged via PR #455)
- Work item SA-0MM8SJX140G614QO was closed (subsumed by this work)
- This PR addresses the remaining timeout enforcement gap (acceptance criterion #5 of SA-0MM3CMZZD1K61ETX)

## Design

The escalation pattern mirrors `BotSupervisor.shutdown()`:
1. `SIGTERM` the process group (using `os.killpg` since child is started with `start_new_session=True`)
2. Wait up to 5 seconds for graceful exit
3. `SIGKILL` the process group if still alive

A daemon `threading.Timer` is used so `dispatch()` can return immediately, preserving the fire-and-forget contract.

## Test Results

All 969 tests pass (1 xfailed), no regressions.

## Files Changed

- `ampa/engine/dispatch.py` — Added `_enforce_timeout()`, `_TIMEOUT_GRACE_PERIOD`, and timer wiring in `dispatch()`
- `tests/test_dispatch.py` — Added `TestEnforceTimeout` class (6 tests) + `test_dispatch_starts_timer`

Closes SA-0MM8SJKC31N0PQ55