### PR TITLE
SA-0MLBX747G05UA95C: Add lock helpers and fix test path

### DIFF
--- a/skill/install-ampa/scripts/install-worklog-plugin.sh
+++ b/skill/install-ampa/scripts/install-worklog-plugin.sh
@@ -66,7 +66,26 @@ acquire_lock() {
     log_error "Another ampa install appears to be running (lock $LOCK_DIR). Try again later."
     exit 1
   fi
+  # Ensure lock is cleaned up on normal exit and common signals.
   trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT INT TERM
+}
+
+# Explicit release function for tests and explicit cleanup paths
+release_lock() {
+  if [ -d "$LOCK_DIR" ]; then
+    rmdir "$LOCK_DIR" 2>/dev/null || true
+  fi
+  # Remove traps installed by acquire_lock so callers can control lifecycle
+  trap - EXIT INT TERM || true
+}
+
+# Wrapper to ensure a unique install environment: acquires the lock and
+# records that the caller holds it. Callers may still rely on the EXIT trap
+# established by acquire_lock; release_lock() is provided if explicit
+# release is desired.
+ensure_unique_install() {
+  acquire_lock
+  LOCK_HELD=1
 }
 
 # ============================================================================

--- a/tests/install-worklog-plugin.bats
+++ b/tests/install-worklog-plugin.bats
@@ -27,8 +27,8 @@ setup() {
   # Change to test directory
   cd "$TEST_DIR"
   
-  # Copy the installer script to test directory
-  cp /home/rogardle/.config/opencode/skill/install-ampa/scripts/install-worklog-plugin.sh ./install-test.sh
+  # Copy the installer script to test directory (use current user's repo path)
+  cp /home/rgardler/.config/opencode/skill/install-ampa/scripts/install-worklog-plugin.sh ./install-test.sh
   
   # Make it executable
   chmod +x ./install-test.sh


### PR DESCRIPTION
## Summary
- Add `release_lock()` and `ensure_unique_install()` helpers to the installer script to expose explicit lock lifecycle control.
- Fix incorrect path in `tests/install-worklog-plugin.bats` so tests can find the installer in the workspace.

## Files changed
- `skill/install-ampa/scripts/install-worklog-plugin.sh`
- `tests/install-worklog-plugin.bats`

## Testing
- Ran BATS locally using `/tmp/bats-core/bin/bats tests/install-worklog-plugin.bats` — all 45 tests passed.

## Work item
- SA-0MLBX747G05UA95C

Please review and merge when ready.