### PR TITLE
SA-0MM8QJO8J1HS273Q: Wire auto-delegate runner into scheduler

### DIFF
--- a/ampa/auto_delegate.py
+++ b/ampa/auto_delegate.py
@@ -32,7 +32,7 @@ import json
 import logging
 import subprocess
 import time
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 LOG = logging.getLogger("ampa.auto_delegate")
 

--- a/ampa/scheduler.py
+++ b/ampa/scheduler.py
@@ -77,6 +77,7 @@ from .scheduler_helpers import (  # noqa: E402
     clear_stale_running_states as _clear_stale_running_states,
     ensure_watchdog_command as _ensure_watchdog_command,
     ensure_test_button_command as _ensure_test_button_command,
+    ensure_auto_delegate_command as _ensure_auto_delegate_command,
     send_test_button_message as _send_test_button_message,
     log_health as _log_health,
 )
@@ -239,6 +240,11 @@ class Scheduler:
         # "Blue or Red?" message with discord.ui.Button components is sent
         # every 15 minutes (MVP validation for interactive buttons).
         _ensure_test_button_command(self.store)
+
+        # Auto-register the auto-delegate command (disabled by default for
+        # safe rollout).  When enabled it periodically runs ``wl next`` and
+        # delegates plan-complete high/critical items.
+        _ensure_auto_delegate_command(self.store)
 
         # --- Discord bot process supervision ---
         self._bot_supervisor = BotSupervisor(
@@ -602,6 +608,26 @@ class Scheduler:
                 _send_test_button_message(notifications_module)
             except Exception:
                 LOG.exception("Test-button message failed")
+            return run
+        if spec.command_type == "auto-delegate":
+            try:
+                meta = getattr(spec, "metadata", {}) or {}
+                if not meta.get("enabled"):
+                    LOG.debug(
+                        "auto-delegate: command disabled via metadata.enabled"
+                    )
+                    return run
+                from .auto_delegate import AutoDelegateRunner
+
+                runner = AutoDelegateRunner(
+                    run_shell=self.run_shell,
+                    command_cwd=self.command_cwd,
+                    notifier=notifications_module,
+                )
+                result = runner.run(spec)
+                LOG.info("auto-delegate result: %s", result)
+            except Exception:
+                LOG.exception("auto-delegate command failed")
             return run
 
         # always post the generic discord notification afterwards

--- a/ampa/scheduler_helpers.py
+++ b/ampa/scheduler_helpers.py
@@ -23,6 +23,7 @@ LOG = logging.getLogger("ampa.scheduler")
 
 _WATCHDOG_COMMAND_ID = "stale-delegation-watchdog"
 _TEST_BUTTON_COMMAND_ID = "test-button"
+_AUTO_DELEGATE_COMMAND_ID = "auto-delegate"
 
 
 # ---------------------------------------------------------------------------
@@ -141,6 +142,42 @@ def ensure_test_button_command(store: SchedulerStore) -> None:
         )
     except Exception:
         LOG.exception("Failed to auto-register test-button command")
+
+
+def ensure_auto_delegate_command(store: SchedulerStore) -> None:
+    """Register the auto-delegate command if absent.
+
+    The command is **disabled by default** (``metadata.enabled = False``)
+    so operators must opt-in via their store configuration.
+    """
+    try:
+        existing = store.list_commands()
+        for cmd in existing:
+            if cmd.command_id == _AUTO_DELEGATE_COMMAND_ID:
+                LOG.debug(
+                    "Auto-delegate command already registered: %s",
+                    _AUTO_DELEGATE_COMMAND_ID,
+                )
+                return
+        auto_delegate_spec = CommandSpec(
+            command_id=_AUTO_DELEGATE_COMMAND_ID,
+            command="echo auto-delegate",
+            requires_llm=False,
+            frequency_minutes=30,
+            priority=0,
+            metadata={"enabled": False},
+            title="Auto Delegate",
+            max_runtime_minutes=5,
+            command_type="auto-delegate",
+        )
+        store.add_command(auto_delegate_spec)
+        LOG.info(
+            "Auto-registered auto-delegate command: %s (every %dm, disabled by default)",
+            _AUTO_DELEGATE_COMMAND_ID,
+            auto_delegate_spec.frequency_minutes,
+        )
+    except Exception:
+        LOG.exception("Failed to auto-register auto-delegate command")
 
 
 # ---------------------------------------------------------------------------

--- a/ampa/scheduler_store_example.json
+++ b/ampa/scheduler_store_example.json
@@ -95,6 +95,23 @@
       "priority": 0,
       "requires_llm": false,
       "type": "delegation"
+    },
+    "auto-delegate": {
+      "command": "echo auto-delegate",
+      "frequency_minutes": 30,
+      "id": "auto-delegate",
+      "title": "Auto Delegate",
+      "max_runtime_minutes": 5,
+      "metadata": {
+        "enabled": false,
+        "eligible_stages": ["plan_complete"],
+        "eligible_priorities": ["high", "critical"],
+        "max_retries": 3,
+        "retry_backoff_base_seconds": 2.0
+      },
+      "priority": 0,
+      "requires_llm": false,
+      "type": "auto-delegate"
     }
   },
   "last_global_start_ts": "2026-02-05T07:51:52.053932+00:00",

--- a/tests/test_scheduler_scoring.py
+++ b/tests/test_scheduler_scoring.py
@@ -53,6 +53,12 @@ def _make_scheduler(now: dt.datetime, llm_available: bool) -> Scheduler:
         "test-button",
         {"last_run_ts": now.isoformat()},
     )
+    # Same for the auto-delegate command (auto-registered at init,
+    # disabled by default).
+    scheduler.store.update_state(
+        "auto-delegate",
+        {"last_run_ts": now.isoformat()},
+    )
     return scheduler
 
 


### PR DESCRIPTION
## Summary

Integrates the existing `AutoDelegateRunner` (`ampa/auto_delegate.py`) into the scheduler framework so it runs as a scheduled command.

**Work item:** SA-0MM8QJO8J1HS273Q — "Auto-delegate scheduler command: run wl next and delegate plan-complete high/critical items"

## Changes

- **`ampa/scheduler_helpers.py`** — Added `ensure_auto_delegate_command()` to auto-register the `auto-delegate` command at scheduler init (disabled by default, 30-minute cadence)
- **`ampa/scheduler.py`** — Imported and called `ensure_auto_delegate_command` in `Scheduler.__init__()`, added `"auto-delegate"` routing block in `start_command()` that checks `metadata.enabled`, instantiates `AutoDelegateRunner`, and calls `runner.run(spec)`
- **`ampa/scheduler_store_example.json`** — Added `"auto-delegate"` entry with configurable metadata (`enabled`, `eligible_stages`, `eligible_priorities`, `max_retries`, `retry_backoff_base_seconds`)
- **`ampa/auto_delegate.py`** — Fixed missing `Tuple` import from `typing`
- **`tests/test_scheduler_scoring.py`** — Updated `_make_scheduler()` helper to set a recent `last_run_ts` for the auto-registered `auto-delegate` command, preventing it from interfering with scoring tests

## Acceptance Criteria

- [x] Scheduler command runs on configured cadence (every 30 min default) and calls `wl next --json`
- [x] When `wl next` returns item with `stage == plan_complete` and `priority` in (`high`, `critical`), runs `wl gh delegate <id>` and logs the action
- [x] If `wl gh delegate` fails, retries up to 3 times with exponential backoff; persistent failure posts Discord notification
- [x] Command is configurable in `scheduler_store_example.json` and can be disabled by default
- [x] Command is disabled by default for safe rollout (`metadata.enabled = false`)
- [x] Does not require LLM availability (`requires_llm: false`)

## Testing

All 1053 tests pass (3 skipped, 1 xfailed), including 28 auto-delegate tests (5 scheduler integration tests) and 5 scheduler scoring tests.