### PR TITLE
SA-0MN1M1YTV01LKEM5: Add Playwright browser smoke test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,22 +5,27 @@
   "packages": {
     "": {
       "dependencies": {
-        "@opencode-ai/plugin": "1.2.15"
+        "@opencode-ai/plugin": "1.2.6"
       },
       "devDependencies": {
-        "bats": "^1.13.0"
+        "bats": "^1.13.0",
+        "playwright": "1.58.2"
       }
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.2.15",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.2.6.tgz",
+      "integrity": "sha512-CJEp3k17yWsjyfivm3zQof8L42pdze3a7iTqMOyesHgJplSuLiBYAMndbBYMDuJkyAh0dHYjw8v10vVw7Kfl4Q==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.2.15",
+        "@opencode-ai/sdk": "1.2.6",
         "zod": "4.1.8"
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.2.15",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.2.6.tgz",
+      "integrity": "sha512-dWMF8Aku4h7fh8sw5tQ2FtbqRLbIFT8FcsukpxTird49ax7oUXP+gzqxM/VdxHjfksQvzLBjLZyMdDStc5g7xA==",
       "license": "MIT"
     },
     "node_modules/bats": {
@@ -31,6 +36,53 @@
       "license": "MIT",
       "bin": {
         "bats": "bin/bats"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
+  "scripts": {
+    "test:smoke:node": "node --test tests/node/test-browser-smoke.mjs"
+  },
   "dependencies": {
     "@opencode-ai/plugin": "1.2.6"
   },
   "devDependencies": {
-    "bats": "^1.13.0"
+    "bats": "^1.13.0",
+    "playwright": "1.58.2"
   }
 }

--- a/tests/node/test-browser-smoke.mjs
+++ b/tests/node/test-browser-smoke.mjs
@@ -1,0 +1,30 @@
+/**
+ * Browser smoke test — proves whether the current environment has the
+ * system/runtime dependencies required to launch Playwright's Chromium.
+ *
+ * Pass:  host with Playwright and Chromium installed.
+ * Fail:  ampa-dev:latest container (missing system deps), demonstrating
+ *        the gap that SA-0MN1M2L330YNA1FU will address.
+ *
+ * Run:
+ *   node --test tests/node/test-browser-smoke.mjs
+ *   npm run test:smoke:node
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { chromium } from 'playwright';
+
+test('Chromium launches headlessly and can navigate to about:blank', async () => {
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage();
+    await page.goto('about:blank');
+    const title = await page.title();
+    // about:blank has an empty string title — assert it is defined (not null/undefined)
+    assert.notEqual(title, null, 'page.title() should not be null');
+    assert.notEqual(title, undefined, 'page.title() should not be undefined');
+  } finally {
+    await browser.close();
+  }
+});


### PR DESCRIPTION
## Summary

Adds a minimal Node.js smoke test that uses Playwright to attempt launching Chromium. The test demonstrates whether the current `ampa-dev:latest` container image has the system/browser runtime dependencies required to run headless Chromium.

## Changes

1. **package.json**:
   - Added `playwright` as a devDependency with exact pinned version `1.58.2`
   - Added npm script `test:smoke:node` for convenience

2. **tests/node/test-browser-smoke.mjs**:
   - Launches Chromium headlessly via Playwright
   - Navigates to `about:blank`
   - Asserts page title is defined (not null/undefined)
   - Properly closes browser in finally block

## Test Results

**On host (with Playwright/Chromium installed):**
```
✔ Chromium launches headlessly and can navigate to about:blank (527ms)
ℹ pass 1, fail 0
```

**In ampa-dev:latest container:**
Fails as expected with missing system dependencies (libnspr4.so), proving the container image gap that SA-0MN1M2L330YNA1FU will address.

## Verification

- [x] Playwright pinned to exact version for reproducibility
- [x] Test file created and runnable via `node --test`
- [x] npm script added for convenience
- [x] Test passes on host with proper setup
- [x] Test fails in container (proving missing deps)
- [x] No CI modifications (as requested)
- [x] All existing AMPA tests still pass (21/21)

## Related Work Items

- SA-0MN1M1YTV01LKEM5 (this PR)
- SA-0MN1M2L330YNA1FU (add Playwright deps to Containerfile - blocked by this test)
- SA-0MN0VR4QU180IKU7 (parent umbrella work item)

## Testing

Run the smoke test:
```bash
npm install
npx playwright install chromium
npm run test:smoke:node
```

Or run directly:
```bash
node --test tests/node/test-browser-smoke.mjs
```