### PR TITLE
Fix build → test → commit order in all agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,19 +58,18 @@ Follow thhe steps below when completing tasks. If you are already working on a s
    - Create a new branch for the work-item following the branch naming conventions (e.g. `wl-<WIP-id>-short-description`)
    - Complete all work required to meet the acceptance criteria (code, tests, documentation, etc.)
      - If new work-items are discovered during implementation create new work-items using `wl create "<work-item-title>" --description "<detailed-description-of-goals-and-context>" --issue-type <type-of-work-item> --json`. If the item must be completed in order to satisfy the requirements of the parent work-item, make the new item a child of the parent work-item using `--parent <parent-id>`. If it is an optional item make it a sibling of the <base-item-id> and add a reference to the base item in the description using `discovered-from:<base-item-id>`.
-     - Regularly build and run all tests and checks to ensure nothing is broken
+     - Regularly build the project and run all tests and checks to ensure nothing is broken. Always follow the build → test → commit order: build first, then test, then commit.
        - If the build or any tests/checks fail, fix the issues and repeat until all tests/checks pass
-     - Commit changes whenever the Producer observes that a significant amount of progress has been made (ask if you think it is due), use clear commit messages that reference the WIP id and summarise the changes made.
+     - Commit changes only after the build completes without errors and all tests pass. Before committing, always run the build first, then the test suite, and only commit if both succeed. Never commit before verifying that the build and tests pass. When committing, use clear commit messages that reference the WIP id and summarise the changes made.
    - If a particularly complex issue is identified or a significant design decisions or assumption is made record this in a comment on the work-item using `wl comment add <WIP-id> --comment "<detailed-comment>" --author <your-agent-name> --json`
-   - Once the acceptance criteria of <WIP-id> has been satisfied and all tests pass (meaning you have built the project, rebuilt the application, and run all tests successfully), commit final changes to the branch with a message such as `<WIP-id>: Completed work to satisfy acceptance criteria: <acceptance-criteria-summary>`
+   - Once the acceptance criteria of <WIP-id> has been satisfied, follow the mandatory build → test → commit order: first build the project (verify no errors), then run all tests (verify all pass), and only then commit final changes to the branch with a message such as `<WIP-id>: Completed work to satisfy acceptance criteria: <acceptance-criteria-summary>`
    - When work is complete record a comment on the work-item summarising the changes made and the reason for them, including the commit hash using `wl comment add <id> --comment "Completed work, see commit <commit-hash> for details." --author <your-agent-name> --json`
    - Update the work-item stage to `in_review` using `wl update <WIP-id> --stage in_review`
    - Report back to the operator summarising the work completed and proceed to the next step.
 6. **Merge work into main**:
    - Update the branch to bring it into line with main
      - resolve any conflicts that arise
-   - Build the application and run all tests and checks to ensure nothing is broken
-     - If the build failes or any tests/checks fail, fix the issues and repeat until all tests/checks pass
+   - Build the project and run all tests and checks to ensure nothing is broken. Only proceed with merging after the build succeeds without error and all tests pass.
    - Push the branch to the remote repository
    - Switch back to main, merge the branch and push the updated main branch to the remote repository
    - Close the work-item with a comment summarising the changes made and the reason for them, including the commit hash using `wl close <WIP-id> --reason "Completed work, see merge commit <merge-commit-hash> for details." --json`
@@ -102,7 +101,8 @@ IMPORTANT: This project uses Worklog (wl) for ALL work-item tracking. Do NOT use
 - Always ensure that any work-item created is associated with a clear goal and context, preferably in the form of a user story, along with measurable and testable acceptance criteria. If the requirements are not clear, seek clarification and update the work-item accordingly before proceeding with implementation.
 - When writing content for work-item descriptions, comments, or commit messages, do not escape special character EXCEPT backticks. Use markdown formatting as needed for clarity and readability, but do not add unnecessary escaping that could reduce readability or cause confusion.
 - Never commit changes without associating them with a work item
-- Never commit changes without ensuring all tests and quality checks pass
+- Never commit changes without ensuring the build completes without errors and all tests and quality checks pass
+- Always follow the build → test → commit order: first build the project and verify no errors, then run all tests and verify they pass, and only then commit changes. Never reverse this order or skip steps.
 - Before reporting coding work as done (for example marking a work-item ready for review or closing it locally), agents MUST rebuild the application and run the full test suite locally, confirming the build completes successfully and there are no failing tests or runtime errors.
 - Always record the commit message and hash of any commits made in a comment on the relevant work item(s)
 - Whenever a comment is made add a comment to impacted the work item(s) describing the changes, the files affected, and including the commit hash.

--- a/agent/patch.md
+++ b/agent/patch.md
@@ -28,7 +28,7 @@ Focus on:
 - Keeping tests and docs in sync with behavior changes, adding coverage when risk warrants
 - Surfacing blockers, risky refactors, or missing context early to the Producer and peer agents
 - Implement the smallest change that meets acceptance criteria, using `git diff` frequently to keep scope tight.
-- Run the most targeted checks available (`npm test`, `npm run build`, or narrower suites) and summarize results.
+- Always follow the mandatory build → test → commit order: build the project and verify no errors, then run the most targeted checks available (`npm test`, `npm run build`, or narrower suites) and verify they pass, and only then commit. Never commit before verifying that the build and tests pass.
 - Summaries in the Worklog must list every command executed, tests/docs touched (including `history/` planning artifacts), and remaining risks or follow-ups before handing off.
 
 Boundaries:

--- a/agent/ship.md
+++ b/agent/ship.md
@@ -28,7 +28,7 @@ Focus on:
 - Designing/validating CI, packaging, and release steps in small, reviewable increments
 - Surfacing operational risks (missing smoke tests, versioning gaps, flaky builds) with actionable mitigation plans
 - Inspect current build/test config via `git diff`, package scripts, and npm configs before proposing changes.
-- Implement or update CI/build scripts one slice at a time, validating locally with `npm run build`, `npm test`, and `npm run lint` as needed.
+- Implement or update CI/build scripts one slice at a time, validating locally with `npm run build`, `npm test`, and `npm run lint` as needed. Always follow the mandatory build → test → commit order: build first and verify no errors, then run all tests and verify they pass, and only then commit. Never commit before verifying that the build and tests pass.
  - Record validation steps, commands run, files/docs touched (including any `history/` planning artifacts), outcomes, and recommended follow-ups in the Worklog so operators know what’s covered and what remains.
 - Ensure `main` is always releasable; avoid direct-to-main changes.
 - Use a git branch + PR workflow; do not push directly to `main`.

--- a/command/complex_implement.md
+++ b/command/complex_implement.md
@@ -34,7 +34,7 @@ You are implementing a Worklog work item identified by a provided id. You will f
 
 - Use `wl` for ALL task tracking; do not create markdown TODOs.
 - Keep changes between `git push` invocations minimal and scoped to the work item.
-- Always run tests and validation before committing changes.
+- Always build the project and run all tests before committing changes. Follow the mandatory build → test → commit order: build first and verify no errors, then run all tests and verify they pass, and only then commit. Never commit before verifying that the build and tests pass.
 - Use a git branch + PR workflow (no direct-to-main changes).
 - Ensure the working branch is pushed to `origin` before finishing.
 - Do NOT close the Worklog work item until the PR is merged.

--- a/skill/implement/SKILL.md
+++ b/skill/implement/SKILL.md
@@ -55,6 +55,7 @@ any sensitive values before writing them to logs or comments.
 - If the work item is not well-defined, do not proceed with implementation. Instead, run the intake interview to clarify and update the work item before implementing.
 - If the work item has blockers or dependencies, implement those first before proceeding with the main work item.
 - Never commit directly to `main`. Always create a feature or bug branch for implementation.
+- The required order of operations before any commit is always: **build → test → commit**. First build the project and verify no errors, then run all tests and verify they pass, and only then commit. Never commit before verifying that the build and tests pass.
 - When creating branches, include the work item id in the branch name for traceability (e.g., `feature/WL-123-add-auth`).
 - When creating a commit message, review the diff and write a concise message summarizing the changes made and the reason for the change, referencing the work item id.
 - When committing add a comment to the work item with the commit message and hash.
@@ -119,7 +120,7 @@ Execute the following steps in order. Do not skip steps. Use the live commands w
   - Select the most appropriate work item to work on next (blocker > dependency; most critical first).
   - Claim the work item by running `wl update <work-item-id> --status in_progress --stage in_progress --assignee "<AGENT>" --json`
   - Recursively implement that work item as described in this procedure.
-  - When a work item is completed commit the work and update the stage: `wl update <work-item-id> --status in_progress --stage in_review --json`
+  - When a work item is completed, follow the mandatory build → test → commit order: first build the project and verify no errors, then run all tests and verify they pass, and only then commit the work. Update the stage: `wl update <work-item-id> --status in_progress --stage in_review --json`
 
 - If the work item does not have a recorded audit (see the output of wl show <work-item-id> --json) go to the next item in this step of the process, otherwise:
   - review the audit notes and address any unmet acceptance criteria or other issues identified.
@@ -131,6 +132,7 @@ Execute the following steps in order. Do not skip steps. Use the live commands w
   - Add comments to the work item describing any significant design decisions, code edits or tradeoffs.
   - If additional work is discovered, create linked work items: `wl create "<title>" --deps discovered-from:<work-item-id> --json`
 - Once all acceptance criteria for the primary work item and all blockers and dependents are met:
+  - Build the project and verify the build completes without errors.
   - Run the entire test suite.
     - Report the reults
     - Fix any failing tests before continuing.
@@ -155,6 +157,7 @@ Execute the following steps in order. Do not skip steps. Use the live commands w
 
 5. Commit, Push and create PR
 
+- Before committing, follow the mandatory build → test → commit order: build the project and verify no errors, then run all tests and verify they pass, and only then commit changes.
 - Ensure all work has been committed
 - Push the branch to `origin`.
 - Create a Pull Request (PR) against the repository's default branch.

--- a/skill/resolve-pr-comments/SKILL.md
+++ b/skill/resolve-pr-comments/SKILL.md
@@ -164,9 +164,18 @@ For each approved actionable fix:
 1. Use Edit tool to make the change
 2. Track which comment IDs were addressed
 
-#### Step 3.2: Commit and push
+#### Step 3.2: Build, test, commit and push
+
+Before committing, follow the mandatory build → test → commit order: build the project and verify no errors, then run all tests and verify they pass, and only then commit changes. Never commit before verifying that the build and tests pass.
 
 ```bash
+# Build the project first
+npm run build  # or the project's build command
+
+# Then run all tests
+npm test  # or the project's test command
+
+# Only commit after build and tests pass
 git add <modified_files>
 git commit -m "Address PR review feedback
 


### PR DESCRIPTION
## Goal

Ensure all agent instruction files unambiguously state that the correct order of operations is: **build → test → commit**. No code should ever be committed before verifying that the build completes without errors and all tests pass.

## Problem

Agents sometimes commit code before verifying that the build and tests pass. This is caused by ambiguous language in agent instruction files, most notably in AGENTS.md which says "Commit changes whenever the Producer observes that a significant amount of progress has been made" without requiring build or test verification first.

## Changes Made

- **AGENTS.md**: Reworded commit guidance to require build+test pass before committing; added explicit build → test → commit rule to CRITICAL RULES section; updated merge step to require build+test before merging
- **agent/patch.md**: Added mandatory build → test → commit order to Focus section
- **agent/ship.md**: Added mandatory build → test → commit order to Focus section
- **command/complex_implement.md**: Expanded "run tests and validation before committing" to explicitly require build first, then test, then commit
- **skill/implement/SKILL.md**: Added build → test → commit rule to best practices; updated steps 3, 4, and 5 to require build before test before commit
- **skill/resolve-pr-comments/SKILL.md**: Renamed Step 3.2 from "Commit and push" to "Build, test, commit and push"; added build and test steps before commit

## How to verify

1. Search all agent instruction files for "commit" and verify that every instruction that mentions committing also requires build and test to pass first
2. Verify that no instruction file allows or implies committing before testing
3. Run the test suite: `python -m pytest tests/`

## Focus for review

Focus on whether the build → test → commit order is now unambiguous in all relevant files and whether any files were missed.

Work item: SA-0MPAZORLO00507ZU