### PR TITLE
SA-0MPAVWCEA0080NUH: Add line breaks between thought blocks in pi streaming output

### DIFF
--- a/skill/ralph/scripts/ralph_loop.py
+++ b/skill/ralph/scripts/ralph_loop.py
@@ -962,6 +962,7 @@ class RalphLoop:
         stderr_parts: list[str] = []
         json_lines_seen = 0
         text_lines_seen = 0
+        needs_newline_sep = False
         stdout_queue: Queue[object] = Queue()
         eof_marker = object()
         stream_error: BaseException | None = None
@@ -1036,6 +1037,9 @@ class RalphLoop:
                 stream_text, should_print, complete_text = _parse_pi_json_line(stripped)
                 if stream_text is None and complete_text is None:
                     # Not valid JSON — show raw line as fallback
+                    if needs_newline_sep:
+                        print()
+                        needs_newline_sep = False
                     print(line, end="", flush=True)
                     text_parts.append(line)
                     text_lines_seen += 1
@@ -1046,12 +1050,21 @@ class RalphLoop:
                     json_lines_seen += 1
                     if should_print and stream_text:
                         # User-facing additive text delta — show to operator
+                        if needs_newline_sep:
+                            print()
+                            needs_newline_sep = False
                         print(stream_text, end="", flush=True)
                         text_parts.append(stream_text)
                         text_lines_seen += 1
                     if complete_text:
                         # Complete content block — capture for return value
                         complete_blocks.append(complete_text)
+                        if text_lines_seen > 0:
+                            needs_newline_sep = True
+                    elif not should_print and text_lines_seen > 0:
+                        # Suppressed JSON event (thinking, tool, structural, etc.)
+                        # — flag that the next printable text needs a newline separator
+                        needs_newline_sep = True
                     # In verbose mode, also log the raw JSON line
                     if self.verbose:
                         logger.debug("ralph.cmd.pi.json_line %s", stripped[:500])

--- a/skill/ralph/tests/test_stream_output.py
+++ b/skill/ralph/tests/test_stream_output.py
@@ -1,0 +1,148 @@
+"""Tests for streaming output in ralph_loop._stream_pi, specifically that
+text blocks separated by suppressed events (thinking, etc.) get a newline
+separator between them."""
+
+import io
+import json
+import subprocess
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+from skill.ralph.scripts.ralph_loop import RalphLoop
+
+
+def _fake_process(lines: list[str], returncode: int = 0) -> MagicMock:
+    """Create a mock subprocess.Popen that yields the given lines from stdout."""
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.poll.return_value = returncode
+    proc.wait.return_value = returncode
+
+    class FakeStream:
+        def __init__(self, lines):
+            self._lines = list(lines)
+            self._idx = 0
+
+        def readline(self, size=-1):
+            if self._idx < len(self._lines):
+                line = self._lines[self._idx]
+                self._idx += 1
+                return line
+            return ""
+
+        def read(self, size=-1):
+            return ""
+
+        def close(self):
+            pass
+
+    proc.stdout = FakeStream(lines)
+    proc.stderr = FakeStream([])
+    return proc
+
+
+def _json_line(event: dict) -> str:
+    """Return a line as readline() would yield it: JSON + trailing newline."""
+    return json.dumps(event) + "\n"
+
+
+def _event(event_type: str, assistant_type: str | None = None, **extra) -> dict:
+    d = {"type": event_type}
+    if assistant_type is not None:
+        d["assistantMessageEvent"] = {"type": assistant_type, **extra}
+    else:
+        d.update(extra)
+    return d
+
+
+def test_stream_pi_adds_newline_between_thought_blocks():
+    """When text_delta events are separated by thinking (suppressed) events,
+    a newline should be printed between them."""
+    lines = [
+        _json_line(_event("message_update", "text_delta", delta="First thought.")),
+        _json_line(_event("message_update", "thinking_start")),
+        _json_line(_event("message_update", "thinking_end")),
+        _json_line(_event("message_update", "text_delta", delta="Second thought.")),
+        _json_line(_event("message_update", "text_delta", delta=" Continued.")),
+    ]
+    proc = _fake_process(lines)
+    loop = RalphLoop(pi_bin="pi", stream=True, verbose=False)
+
+    with (
+        patch("subprocess.Popen", return_value=proc) as mock_popen,
+        redirect_stdout(io.StringIO()) as buf,
+    ):
+        result = loop._stream_pi(["pi", "-p", "--mode", "json", "prompt"], "prompt")
+
+    output = buf.getvalue()
+    # Should have a newline between the two thought blocks
+    assert "First thought.\nSecond thought." in output, (
+        f"Expected newline between thought blocks, got: {repr(output)}"
+    )
+
+
+def test_stream_pi_no_leading_newline():
+    """The first text_delta should NOT have a leading newline."""
+    lines = [
+        _json_line(_event("message_update", "text_delta", delta="First thought.")),
+    ]
+    proc = _fake_process(lines)
+    loop = RalphLoop(pi_bin="pi", stream=True, verbose=False)
+
+    with (
+        patch("subprocess.Popen", return_value=proc),
+        redirect_stdout(io.StringIO()) as buf,
+    ):
+        loop._stream_pi(["pi", "-p", "--mode", "json", "prompt"], "prompt")
+
+    output = buf.getvalue()
+    assert output == "First thought.", f"Expected no leading newline, got: {repr(output)}"
+
+
+def test_stream_pi_newline_after_complete_text():
+    """When a text_end event fires followed by a new text_delta (e.g. after
+    tool use), a newline should separate the blocks."""
+    lines = [
+        _json_line(_event("message_update", "text_delta", delta="Block one.")),
+        _json_line(_event("message_update", "text_end", content="Block one.")),
+        _json_line(_event("message_update", "text_delta", delta="Block two.")),
+        _json_line(_event("message_update", "text_delta", delta=" More.")),
+    ]
+    proc = _fake_process(lines)
+    loop = RalphLoop(pi_bin="pi", stream=True, verbose=False)
+
+    with (
+        patch("subprocess.Popen", return_value=proc),
+        redirect_stdout(io.StringIO()) as buf,
+    ):
+        loop._stream_pi(["pi", "-p", "--mode", "json", "prompt"], "prompt")
+
+    output = buf.getvalue()
+    assert "Block one.\nBlock two." in output, (
+        f"Expected newline between complete text blocks, got: {repr(output)}"
+    )
+
+
+def test_stream_pi_continuous_deltas_no_extra_newlines():
+    """Continuous text_delta events within the same block should not get
+    extra newlines between them."""
+    lines = [
+        _json_line(_event("message_update", "text_delta", delta="Hello ")),
+        _json_line(_event("message_update", "text_delta", delta="world")),
+    ]
+    proc = _fake_process(lines)
+    loop = RalphLoop(pi_bin="pi", stream=True, verbose=False)
+
+    with (
+        patch("subprocess.Popen", return_value=proc),
+        redirect_stdout(io.StringIO()) as buf,
+    ):
+        loop._stream_pi(["pi", "-p", "--mode", "json", "prompt"], "prompt")
+
+    output = buf.getvalue()
+    assert output == "Hello world", f"Expected no extra newlines, got: {repr(output)}"


### PR DESCRIPTION
## Summary

When the ralph skill CLI runs a pi command with `--mode json`, the streaming output (`_stream_pi`) prints `text_delta` events to the console. However, when suppressed events (thinking blocks, tool calls, text_end, structural events) separate text blocks, the blocks were concatenated without any separator — for example, `details.Now` instead of `details.\nNow`.

This PR adds a `needs_newline_sep` flag that detects gaps between printable text blocks and inserts a newline separator.

## Work Done

- Added a `needs_newline_sep` flag in `_stream_pi()` that:
  - Gets set to `True` when suppressed events (thinking_*, toolcall_*, structural events, text_end) separate printable text
  - Before printing the next `text_delta` or raw fallback line, prints a `\n` if the flag is set
  - Only activates after at least one character has been printed (no leading newline)
  - Does not affect continuous `text_delta` events within the same block
- Added 4 new tests covering:
  - Newlines between thought blocks separated by thinking events
  - Newlines after complete_text (text_end) blocks
  - No leading newline on first text
  - No extra newlines between continuous deltas

## Files Changed

- `skill/ralph/scripts/ralph_loop.py` (+13 lines)
- `skill/ralph/tests/test_stream_output.py` (new, 148 lines, 4 test cases)

## How to Test Manually

Run the ralph skill with streaming enabled and observe the output. Previously, text blocks separated by model thinking would run together; now they get a newline separator.

## Review Focus

- Verify the `needs_newline_sep` flag correctly tracks gaps without adding spurious newlines
- Confirm edge cases are handled: continuous deltas (no gap), first text (no leading newline), text_end followed by new text block
- Check that the change doesn't affect the return value of `_stream_pi` (only the console output)