### PR TITLE
SA-0MPB08LUB003OJJI: Add work summary to ralph loop success output

### DIFF
--- a/skill/ralph/scripts/ralph_loop.py
+++ b/skill/ralph/scripts/ralph_loop.py
@@ -717,6 +717,7 @@ class RalphLoop:
         self._pi_process: subprocess.Popen | None = None
         self._debug_context: dict[str, object] = {}
         self._last_structured_response: StructuredResponse | None = None
+        self._last_implement_output: str = ""
 
     def _resolve_model_for_phase(self, phase: str) -> str:
         if phase not in MODEL_PHASES:
@@ -1253,19 +1254,44 @@ class RalphLoop:
 
         self._pi_process = None
 
-    def _run_checks(self) -> None:
+    def _run_checks(self) -> list[dict[str, object]]:
+        results: list[dict[str, object]] = []
         for cmd in self.check_cmds:
             quiet_cmd = canonicalize_quiet_test_command(cmd)
             logger.debug("ralph.cmd.check cmd=%s quiet_cmd=%s", cmd, quiet_cmd)
             proc = self._call_with_retry(["bash", "-lc", quiet_cmd], category="check", expect_json=False)
+            result = {
+                "cmd": cmd,
+                "stdout": (getattr(proc, 'stdout', '') or '').strip(),
+                "stderr": (getattr(proc, 'stderr', '') or '').strip(),
+                "returncode": getattr(proc, 'returncode', 0),
+            }
+            results.append(result)
             if self.verbose:
-                logger.debug("ralph.cmd.check stdout=%s", (getattr(proc, 'stdout', '') or '').strip()[:1000])
-                logger.debug("ralph.cmd.check stderr=%s", (getattr(proc, 'stderr', '') or '').strip()[:1000])
-            if getattr(proc, 'returncode', 0) != 0:
+                logger.debug("ralph.cmd.check stdout=%s", result["stdout"][:1000])
+                logger.debug("ralph.cmd.check stderr=%s", result["stderr"][:1000])
+            if result["returncode"] != 0:
                 if self.fail_open and ("check" not in self.fatal_cmds):
-                    logger.warning("ralph.cmd.check.failed_but_fail_open cmd=%s rc=%s stderr=%s", cmd, getattr(proc, 'returncode', None), (getattr(proc, 'stderr', '') or '').strip())
+                    logger.warning("ralph.cmd.check.failed_but_fail_open cmd=%s rc=%s stderr=%s", cmd, result["returncode"], result["stderr"])
                     continue
-                raise RalphError(f"Check failed ({cmd}): {(getattr(proc, 'stderr', '') or '').strip() or (getattr(proc, 'stdout', '') or '').strip()}")
+                raise RalphError(f"Check failed ({cmd}): {result['stderr'] or result['stdout']}")
+        return results
+
+    def _capture_changed_files(self) -> list[dict[str, str]]:
+        try:
+            proc = self._call_with_retry(["git", "diff", "--name-status", "HEAD"], category="summary", expect_json=False)
+            output = (getattr(proc, 'stdout', '') or '').strip()
+            if not output:
+                return []
+            files: list[dict[str, str]] = []
+            for line in output.splitlines():
+                parts = line.strip().split("\t", 1)
+                if len(parts) == 2:
+                    files.append({"status": parts[0], "file": parts[1]})
+            return files
+        except Exception:
+            logger.warning("ralph.summary.git_diff_failed", exc_info=True)
+            return []
 
     def _run_merge(self) -> None:
         if not self.confirm_merge:
@@ -1800,6 +1826,7 @@ class RalphLoop:
                     )
                     previous_child_stages = {}
                 implement_output = self._run_pi(_build_implement_prompt(focus_id, remediation), phase="intake")
+                self._last_implement_output = implement_output
                 no_safe_path_reason = self._extract_no_safe_path_reason(implement_output)
                 invocations, failures = self._compact_after_child_transition(focus_id, previous_child_stages, attempt)
                 compact_invocations += invocations
@@ -1853,6 +1880,7 @@ class RalphLoop:
                     )
                     previous_child_stages = {}
                 implement_output = self._run_pi(_build_implement_prompt(focus_id, remediation), phase="implementation")
+                self._last_implement_output = implement_output
                 no_safe_path_reason = self._extract_no_safe_path_reason(implement_output)
                 invocations, failures = self._compact_after_child_transition(focus_id, previous_child_stages, attempt)
                 compact_invocations += invocations
@@ -1929,7 +1957,8 @@ class RalphLoop:
 
             if audit.ready_to_close and self._scope_in_review(scope_ids):
                 logger.info("ralph.loop.checks.start target=%s", focus_id)
-                self._run_checks()
+                check_results = self._run_checks()
+                changed_files = self._capture_changed_files()
                 logger.info("ralph.loop.merge target=%s confirm=%s", focus_id, self.confirm_merge)
                 self._run_merge()
                 self._cleanup_pi_process()
@@ -1940,6 +1969,11 @@ class RalphLoop:
                     "merge_offered": True,
                     "merge_executed": self.confirm_merge,
                     "compact": {"invocations": compact_invocations, "failures": compact_failures},
+                    "summary": {
+                        "changed_files": changed_files,
+                        "change_descriptions": self._last_implement_output,
+                        "check_results": check_results,
+                    },
                 }
 
             remediation = _build_remediation_prompt()

--- a/tests/test_ralph_loop.py
+++ b/tests/test_ralph_loop.py
@@ -116,6 +116,9 @@ class FakeRunner:
         if cmd[:2] == ["bash", "-lc"]:
             return Result(stdout="ok")
 
+        if cmd[:2] == ["git", "diff"] and "--name-status" in cmd:
+            return Result(stdout="M\tsrc/foo.py\nA\tsrc/bar.py\n")
+
         if cmd and cmd[0] == "git":
             return Result(stdout="ok")
 
@@ -284,6 +287,77 @@ def test_max_attempts_returns_max_attempts_status():
     result = loop.run("SA-TARGET")
 
     assert result["status"] == "max_attempts"
+
+
+def test_success_result_includes_summary():
+    runner = FakeRunner()
+    runner.audit_outputs = [AUDIT_PASS]
+    loop = RalphLoop(runner=runner, stream=False, check_cmds=["pytest -q"])
+
+    result = loop.run("SA-TARGET")
+
+    assert result["status"] == "success"
+    assert "summary" in result
+    summary = result["summary"]
+    assert isinstance(summary, dict)
+    assert "changed_files" in summary
+    assert "change_descriptions" in summary
+    assert "check_results" in summary
+
+
+def test_summary_changed_files_lists_git_diff():
+    runner = FakeRunner()
+    runner.audit_outputs = [AUDIT_PASS]
+    loop = RalphLoop(runner=runner, stream=False)
+
+    result = loop.run("SA-TARGET")
+
+    assert result["status"] == "success"
+    changed_files = result["summary"]["changed_files"]
+    assert isinstance(changed_files, list)
+    assert len(changed_files) > 0
+    for entry in changed_files:
+        assert "status" in entry
+        assert "file" in entry
+
+
+def test_summary_change_descriptions_from_implement_output():
+    runner = FakeRunner()
+    runner.audit_outputs = [AUDIT_PASS]
+    loop = RalphLoop(runner=runner, stream=False)
+
+    result = loop.run("SA-TARGET")
+
+    assert result["status"] == "success"
+    assert isinstance(result["summary"]["change_descriptions"], str)
+    assert len(result["summary"]["change_descriptions"]) > 0
+
+
+def test_summary_check_results_from_run_checks():
+    runner = FakeRunner()
+    runner.audit_outputs = [AUDIT_PASS]
+    loop = RalphLoop(runner=runner, stream=False, check_cmds=["pytest -q"])
+
+    result = loop.run("SA-TARGET")
+
+    assert result["status"] == "success"
+    check_results = result["summary"]["check_results"]
+    assert isinstance(check_results, list)
+    assert len(check_results) == 1
+    assert check_results[0]["cmd"] == "pytest -q"
+    assert check_results[0]["returncode"] == 0
+    assert check_results[0]["stdout"] == "ok"
+
+
+def test_non_success_results_exclude_summary():
+    runner = FakeRunner()
+    runner.audit_outputs = [AUDIT_FAIL, AUDIT_FAIL]
+    loop = RalphLoop(runner=runner, stream=False, max_attempts=2)
+
+    result = loop.run("SA-TARGET")
+
+    assert result["status"] == "max_attempts"
+    assert "summary" not in result
 
 
 def test_confirm_merge_executes_git_steps():


### PR DESCRIPTION
## Goal

When the ralph loop completes with success status it should summarize:
1. Files changed or added
2. The changes made in each file (primary goals and assumptions)
3. Build and test result summaries

## Work Done

### Code changes (`skill/ralph/scripts/ralph_loop.py`):

- **Stored implement output** in `self._last_implement_output` for later use in the success summary
- **Modified `_run_checks()`** to capture and return check results (cmd, stdout, stderr, returncode) instead of returning `None`
- **Added `_capture_changed_files()`** method that runs `git diff --name-status HEAD` and parses output into structured `{status, file}` entries
- **Success result** now includes a `summary` dict with:
  - `changed_files`: list of `{status, file}` from git diff
  - `change_descriptions`: the implement prompt output describing primary goals and assumptions
  - `check_results`: list of `{cmd, stdout, stderr, returncode}` from check commands

### Tests (`tests/test_ralph_loop.py`):

- Updated `FakeRunner` to return mock git diff output for `git diff --name-status HEAD`
- Added 5 new tests:
  - `test_success_result_includes_summary` — verifies summary field exists with correct structure
  - `test_summary_changed_files_lists_git_diff` — verifies changed_files list content
  - `test_summary_change_descriptions_from_implement_output` — verifies change_descriptions is populated
  - `test_summary_check_results_from_run_checks` — verifies check_results structure and values
  - `test_non_success_results_exclude_summary` — verifies summary absent for max_attempts

### Example success output:

```json
{
  "status": "success",
  "attempt": 2,
  "scope": ["SA-TARGET", "SA-CHILD"],
  "merge_offered": true,
  "merge_executed": false,
  "compact": {"invocations": 1, "failures": 0},
  "summary": {
    "changed_files": [
      {"status": "M", "file": "src/foo.py"},
      {"status": "A", "file": "src/bar.py"}
    ],
    "change_descriptions": "implement SA-TARGET\n...",
    "check_results": [
      {"cmd": "pytest -q", "stdout": "ok", "stderr": "", "returncode": 0}
    ]
  }
}
```

## How to Test

Run the ralph loop on a target work item and verify the final JSON output includes the summary field with changed files, change descriptions, and check results.

## Review Focus

- Verify summary is only included in success results (not max_attempts, cancelled, producer_input_required)
- Verify changed_files parsing handles empty diff output gracefully
- Verify the summary structure matches acceptance criteria