### PR TITLE
Release: merge dev into main

### DIFF
--- a/docs/ralph.md
+++ b/docs/ralph.md
@@ -52,7 +52,7 @@ The background launcher stores the current runtime context in `.worklog/ralph/cu
 |------|---------|-------------|
 | `--max-attempts` | 10 | Maximum number of implement→audit cycles before giving up. |
 | `--check-cmd` | (none) | Build/test command(s) to run after a successful audit. Pytest commands are normalized to `pytest -q -r a --disable-warnings` by default, and package-manager test commands are normalized to quiet variants such as `npm --silent test`. Can be specified multiple times. |
-| `--confirm-merge` | off | Execute `git fetch`, `git merge --ff-only`, `git push` after successful audit and checks. **Without this flag, no merge side effects occur.** |
+| `--confirm-merge` | off | Execute `git fetch`, `git merge --ff-only`, `git push` after successful audit and checks. **Without this flag, no merge side effects occur.**  Note: This direct push to main may fail if server-side branch protection requiring pull requests is enabled. See [Merge Safety Model](#merge-safety-model) for PR-based alternatives. |
 | `--cancel-file` | (none) | Path checked each attempt; if the file exists, the loop stops with status `cancelled`. |
 | `--child` | (none) | Focus the loop on a single direct child work item. Ralph validates that the child belongs to the supplied target and then runs the loop against the child only. |
 | `--debug-persist` | off | Persist raw Pi payloads to `/tmp/ralph-payloads/` when a streamed run produces no user-facing text. |
@@ -278,6 +278,15 @@ Ralph will **never** merge or push without explicit operator confirmation:
 - Without `--confirm-merge`: ralph reports success and notes that merge is available, but performs **no git operations**.
 - With `--confirm-merge`: ralph executes `git fetch origin main`, `git merge --ff-only origin/main`, and `git push origin HEAD`.
 - If any git step fails (e.g., permission denied, push rejected), ralph raises a clear error.
+
+### Branch protection on main
+
+The `--confirm-merge` direct-push approach will **fail** if server-side branch protection requiring pull requests is enabled on `main`. For repositories with branch protection, use one of these alternatives:
+
+1. **Release merge script** (recommended): Use `scripts/release/merge-dev-to-main.sh` which creates a temporary release branch, opens a PR, waits for status checks, and merges via `gh pr merge`. See the [script documentation](../scripts/release/merge-dev-to-main.sh) for usage details.
+2. **Manual PR workflow**: Manually create a PR from your feature branch to `main` using the `gh` CLI, wait for checks to pass, and merge via `gh pr merge --merge --delete-branch`.
+
+The `--confirm-merge` flag is safe to use in repositories **without** branch protection on main, or when the operator has bypass permissions to push directly.
 
 ## Console Output
 

--- a/skill/audit/SKILL.md
+++ b/skill/audit/SKILL.md
@@ -16,10 +16,10 @@ Provide a concise, human-friendly summary of project status or a specific work i
 
 ## Safety and prompt design
 
-- All automated invocations MUST be read-only. Use the designation `[READ-ONLY AUDIT]` in Pi prompts to make this explicit.
-- Do NOT close, modify, create, or delete any work items during an audit. Example phrasing: "Do NOT close, modify, create, or delete any work items.".
-- Do NOT execute any `wl`, `git`, or other state-modifying commands from the model. Do NOT run `wl` commands that change state. If asked to run such commands, refuse and report the request.
-- The model should return a structured markdown report only; if ambiguity is detected, return immediately and do not attempt to persist any audit.
+- Audit executions should be read-only except for the explicit, single persistence step that stores the structured audit into the associated work item. Use the designation `[READ-ONLY AUDIT]` in Pi prompts to mark read-only phases, and use `[PERSIST-AUDIT]` when performing the authorized persistence operation.
+- Do NOT close, create, or delete any work items during an audit. The ONLY permitted state-modifying action for this skill is storing the audit text via the canonical persister (skill/audit/scripts/persist_audit.py) or the runner's built-in persistence; do not perform other `wl`, `git`, or arbitrary state-modifying commands.
+- When persisting, use the canonical persister script or the runner's built-in persistence option. If asked to run arbitrary `wl`, `git`, or other state-modifying commands outside the authorized persister flow, refuse and report the request to the operator.
+- The model should return a structured markdown report. If ambiguity prevents a reliable verdict on acceptance criteria, return immediately and do NOT persist the audit. Persistence must be an explicit, deliberate step — do not persist partial or ambiguous audits.
 - To aid debugging, the canonical runner supports a `--debug-log` flag which appends raw Pi output to a JSONL file (see Scripts section).
 
 ## Structured report (canonical)
@@ -79,14 +79,15 @@ The audit skill ships a small, canonical runner and a persister. Use these from 
   - Persist from a CLI string: `python3 skill/audit/scripts/persist_audit.py --issue-id SA-123 --report "Ready to close: Yes\n..."`
 
 Notes:
-- The runner writes only structured markdown to stdout (the report). Orchestrators must call the persister to persist the report with `wl update <id> --audit-text`.
-- The persister calls: `wl update <issue-id> --audit-text "<report>" --json` and returns a non-zero exit code on failure.
+- The runner supports an optional persistence step. By default the runner will persist the generated structured audit into the work item unless invoked with `--do-not-persist`; use `--do-not-persist` for dry runs. Alternatively, the persister script (`skill/audit/scripts/persist_audit.py`) may be invoked explicitly to store the report. Both mechanisms perform the same `wl update` call and are the approved ways to persist an audit.
+- The persister (and the runner when persisting) call: `wl update <issue-id> --audit-text "<report>" --json` and return a non-zero exit code on failure.
 
 ## Guidance for models
 
 - Return a structured markdown report only. Use the header `Ready to close:` and the canonical sections above.
-- If the model cannot determine acceptance criteria verdicts unambiguously, return immediately and do not persist or claim the audit was recorded.
-- If asked to perform state-modifying wl/git commands, refuse and surface the request to the operator.
+- If the model cannot determine acceptance criteria verdicts unambiguously, return immediately and do NOT persist or claim the audit was recorded.
+- If the report is unambiguous and persistence is requested, you MAY persist the audit using one of the approved persistence mechanisms: the canonical runner (which persists by default unless invoked with `--do-not-persist`) or the persister script (`skill/audit/scripts/persist_audit.py`). When performing the authorized persistence step, annotate the prompt with `[PERSIST-AUDIT]` and ensure the report is final and complete.
+- Do NOT perform arbitrary state-modifying `wl`/`git` commands outside the authorized persister/runner flow. If asked to run such commands, refuse and surface the request to the operator.
 - For debugging, the `--debug-log` flag captures raw Pi output. Use it sparingly and remove sensitive content before sharing.
 
 ## Examples


### PR DESCRIPTION
## Release: merge dev into main

This PR was created automatically by the release merge script.

### Changes included

```
437b2e3 Ensure the audit skill writes the audit to the work item
4c07b59 SA-0MPPLED6I00225LX: Restore branch protection docs in ralph.md (lost in merge 36be4fa)
```

### CI Verification

- **dev-full-suite**: [Run 26878804889](https://github.com/SorraTheOrc/SorraAgents/actions/runs/26878804889)

> _Generated by `scripts/release/merge-dev-to-main.sh`_
